### PR TITLE
アーカイブイベントJSONの読み込みに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Add archive index URLs to `app/config.yaml`.
 ```yaml
 scope:
   archives:
-    - url: https://example.github.io/yamanashi-it-event-archive/index.json
+    - url: https://yuukis.github.io/yamanashi-event-archive/index.json
 ```
 
 See [Archive Index](docs/archive-index.md) for the JSON format.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Add archive index URLs to `app/config.yaml`.
 ```yaml
 scope:
   archives:
-    - url: https://yuukis.github.io/yamanashi-event-archive/index.json
+    - url:
+        - https://yuukis.github.io/yamanashi-event-archive/index.json
 ```
 
 See [Archive Index](docs/archive-index.md) for the JSON format.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ If you have Docker and Docker Compose installed, you can use the following steps
 
 See [API document](https://yuukis.github.io/yamanashi-event-api) for more details.
 
+## Archive Index
+
+Historical events can be loaded from external archive index JSON files. This is
+intended for event data maintained outside this API repository, such as a
+community or regional tech event archive.
+
+Add archive index URLs to `app/config.yaml`.
+
+```yaml
+scope:
+  archives:
+    - url: https://example.github.io/yamanashi-it-event-archive/index.json
+```
+
+See [Archive Index](docs/archive-index.md) for the JSON format.
+
 <!-- LICENSE -->
 ## License
 

--- a/app/archive.py
+++ b/app/archive.py
@@ -45,7 +45,18 @@ class ArchiveIndexRequest:
                 last_modified = datetime.now(timezone.utc)
                 self.__set_json_to_cache(json, last_modified)
 
-            return Group.from_json(json.get("communities", []))
+            source = json.get("source", {})
+            archive_source = source.get("name")
+            archive_url = source.get("url")
+            communities = []
+            for community in json.get("communities", []):
+                item = community.copy()
+                item["archive_source"] = item.get("archive_source",
+                                                  archive_source)
+                item["archive_url"] = item.get("archive_url", archive_url)
+                communities.append(item)
+
+            return Group.from_json(communities)
 
         except requests.RequestException as e:
             raise ArchiveException(500, str(e))

--- a/app/archive.py
+++ b/app/archive.py
@@ -70,6 +70,23 @@ class ArchiveIndexRequest:
     def get_last_modified(self):
         return self.last_modified
 
+    def preload(self):
+        try:
+            json = self.__get_json_from_cache()
+            if json is None:
+                json = self.__get_json()
+                last_modified = datetime.now(timezone.utc)
+                self.__set_json_to_cache(json, last_modified)
+
+        except requests.RequestException as e:
+            raise ArchiveException(500, str(e))
+
+        except ArchiveException as e:
+            raise e
+
+        except Exception as e:
+            raise ArchiveException(500, str(e))
+
     def __find_by_ym_ymd(self, events):
         if len(self.ym) == 0 and len(self.ymd) == 0:
             return events
@@ -94,7 +111,8 @@ class ArchiveIndexRequest:
     def __set_json_to_cache(self, json, last_modified):
         if self.cache is None:
             return
-        self.cache.set(self.__cache_key(), json, last_modified=last_modified)
+        self.cache.set(self.__cache_key(), json, last_modified=last_modified,
+                       ex=None)
 
     def __get_json(self):
         print(f"Fetching archive index from {self.url}")

--- a/app/archive.py
+++ b/app/archive.py
@@ -1,0 +1,99 @@
+import requests
+from datetime import datetime, timezone
+from .models import EventDetail, Group
+
+
+class ArchiveException(Exception):
+    def __init__(self, status_code, message):
+        self.status_code = status_code
+        self.message = message
+
+
+class ArchiveIndexRequest:
+    def __init__(self, url, ym=None, ymd=None, cache=None):
+        self.url = url
+        self.ym = [] if ym is None else ym
+        self.ymd = [] if ymd is None else ymd
+        self.cache = cache
+        self.last_modified = datetime.fromtimestamp(0, timezone.utc)
+
+    def get_events(self):
+        try:
+            json = self.__get_json_from_cache()
+            if json is None:
+                json = self.__get_json()
+                last_modified = datetime.now(timezone.utc)
+                self.__set_json_to_cache(json, last_modified)
+
+            events = EventDetail.from_json(json.get("events", []))
+            return self.__find_by_ym_ymd(events)
+
+        except requests.RequestException as e:
+            raise ArchiveException(500, str(e))
+
+        except ArchiveException as e:
+            raise e
+
+        except Exception as e:
+            raise ArchiveException(500, str(e))
+
+    def get_groups(self):
+        try:
+            json = self.__get_json_from_cache()
+            if json is None:
+                json = self.__get_json()
+                last_modified = datetime.now(timezone.utc)
+                self.__set_json_to_cache(json, last_modified)
+
+            return Group.from_json(json.get("communities", []))
+
+        except requests.RequestException as e:
+            raise ArchiveException(500, str(e))
+
+        except ArchiveException as e:
+            raise e
+
+        except Exception as e:
+            raise ArchiveException(500, str(e))
+
+    def get_last_modified(self):
+        return self.last_modified
+
+    def __find_by_ym_ymd(self, events):
+        if len(self.ym) == 0 and len(self.ymd) == 0:
+            return events
+
+        selected = []
+        for event in events:
+            event_date = event.started_at[:10].replace("-", "")
+            if event_date[:6] in self.ym or event_date in self.ymd:
+                selected.append(event)
+        return selected
+
+    def __get_json_from_cache(self):
+        if self.cache is None:
+            return None
+        cache_content = self.cache.get(self.__cache_key())
+        if cache_content is None:
+            return None
+
+        self.last_modified = cache_content["last_modified"]
+        return cache_content["json"]
+
+    def __set_json_to_cache(self, json, last_modified):
+        if self.cache is None:
+            return
+        self.cache.set(self.__cache_key(), json, last_modified=last_modified)
+
+    def __get_json(self):
+        print(f"Fetching archive index from {self.url}")
+        response = requests.get(self.url)
+        status_code = response.status_code
+        if status_code != 200:
+            raise ArchiveException(status_code, "Failed to fetch archive index")
+
+        self.last_modified = datetime.now(timezone.utc)
+        return response.json()
+
+    def __cache_key(self):
+        return {"archive_index_url": self.url}

--- a/app/archive.py
+++ b/app/archive.py
@@ -2,6 +2,8 @@ import requests
 from datetime import datetime, timezone
 from .models import EventDetail, Group
 
+ARCHIVE_REQUEST_TIMEOUT = 10
+
 
 class ArchiveException(Exception):
     def __init__(self, status_code, message):
@@ -116,7 +118,7 @@ class ArchiveIndexRequest:
 
     def __get_json(self):
         print(f"Fetching archive index from {self.url}")
-        response = requests.get(self.url)
+        response = requests.get(self.url, timeout=ARCHIVE_REQUEST_TIMEOUT)
         status_code = response.status_code
         if status_code != 200:
             raise ArchiveException(status_code, "Failed to fetch archive index")

--- a/app/cache.py
+++ b/app/cache.py
@@ -55,13 +55,19 @@ class EventRequestCache:
         key_last_modified = key + ":last_modified"
 
         self._store[key_content] = content
-        self._expiry[key_content] = datetime.now(timezone.utc).timestamp() + ex
+        if ex is None:
+            self._expiry[key_content] = None
+        else:
+            self._expiry[key_content] = datetime.now(timezone.utc).timestamp() + ex
 
         if last_modified is not None:
             ts = int(last_modified.timestamp())
             self._store[key_last_modified] = ts
-            expiry = datetime.now(timezone.utc).timestamp() + ex
-            self._expiry[key_last_modified] = expiry
+            if ex is None:
+                self._expiry[key_last_modified] = None
+            else:
+                expiry = datetime.now(timezone.utc).timestamp() + ex
+                self._expiry[key_last_modified] = expiry
 
     def generate_key(self, data) -> str:
         if isinstance(data, dict):
@@ -95,6 +101,8 @@ class EventRequestCache:
     def _is_valid(self, key: str) -> bool:
         if key not in self._expiry:
             return False
+        if self._expiry[key] is None:
+            return True
         if datetime.now(timezone.utc).timestamp() > self._expiry[key]:
             self._store.pop(key, None)
             self._expiry.pop(key, None)

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -40,3 +40,6 @@ scope:
       image_url: https://secure-content.meetupstatic.com/images/classic-events/488365181/72x72.jpg
       group_url: https://www.meetup.com/ja-JP/yamanashi-wordpress-meetup/
       ical_url: https://www.meetup.com/ja-JP/Yamanashi-WordPress-Meetup/events/ical/
+
+  archives:
+    - url: https://yuukis.github.io/yamanashi-event-archive/index.json

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -42,4 +42,5 @@ scope:
       ical_url: https://www.meetup.com/ja-JP/Yamanashi-WordPress-Meetup/events/ical/
 
   archives:
-    - url: https://yuukis.github.io/yamanashi-event-archive/index.json
+    - url:
+        - https://yuukis.github.io/yamanashi-event-archive/index.json

--- a/app/main.py
+++ b/app/main.py
@@ -276,7 +276,7 @@ def fetch_events(params):
     try:
         events, last_modified = request_events(params)
 
-    except ConnpassException:
+    except (ConnpassException, IcalException, ArchiveException):
         return
 
     if events is not None:
@@ -394,7 +394,7 @@ def fetch_groups(params):
     try:
         groups, last_modified = request_groups(params)
 
-    except ConnpassException:
+    except (ConnpassException, ArchiveException):
         return
 
     if groups is not None:
@@ -423,7 +423,11 @@ def request_groups(params) -> Tuple[List[Group], datetime]:
             groups += get_groups_from_icalendar(config)
 
         if "scope" in config and "archives" in config["scope"]:
-            groups += get_groups_from_archives(config)
+            archives = config["scope"]["archives"]
+            for archive in archives:
+                r = ArchiveIndexRequest(url=archive["url"], cache=cache)
+                groups += r.get_groups()
+                last_modified = max(last_modified, r.get_last_modified())
 
     except ConnpassException as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from fastapi.responses import RedirectResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
 from .connpass import ConnpassEventRequest, ConnpassGroupRequest, ConnpassException
 from .icalendar import IcalEventRequest, IcalException
+from .archive import ArchiveIndexRequest, ArchiveException
 from .models import Event, EventDetail, Group
 from .cache import EventRequestCache
 import os
@@ -331,10 +332,21 @@ def request_events(params) -> Tuple[List[EventDetail], datetime]:
                 events += r.get_events()
                 last_modified = max(last_modified, r.get_last_modified())
 
+        if "scope" in config and "archives" in config["scope"]:
+            archives = config["scope"]["archives"]
+            for archive in archives:
+                r = ArchiveIndexRequest(url=archive["url"],
+                                        ym=ym, ymd=ymd, cache=cache)
+                events += r.get_events()
+                last_modified = max(last_modified, r.get_last_modified())
+
     except ConnpassException as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
 
     except IcalException as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+    except ArchiveException as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
 
     events = Event.distinct_by_uid(events)
@@ -410,7 +422,13 @@ def request_groups(params) -> Tuple[List[Group], datetime]:
         if "scope" in config and "icalendar" in config["scope"]:
             groups += get_groups_from_icalendar(config)
 
+        if "scope" in config and "archives" in config["scope"]:
+            groups += get_groups_from_archives(config)
+
     except ConnpassException as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+    except ArchiveException as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
 
     return groups, last_modified
@@ -438,5 +456,16 @@ def get_groups_from_icalendar(config):
                 "ical_url": group["ical_url"]
             })
             groups.append(g)
+
+    return groups
+
+
+def get_groups_from_archives(config):
+    groups = []
+    if "scope" in config and "archives" in config["scope"]:
+        archives = config["scope"]["archives"]
+        for archive in archives:
+            r = ArchiveIndexRequest(url=archive["url"], cache=cache)
+            groups += r.get_groups()
 
     return groups

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from .icalendar import IcalEventRequest, IcalException
 from .archive import ArchiveIndexRequest, ArchiveException
 from .models import Event, EventDetail, Group
 from .cache import EventRequestCache
+import asyncio
 import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -28,7 +29,7 @@ connpass_api_key = os.getenv("CONNPASS_API_KEY")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    preload_archive_indexes()
+    await asyncio.to_thread(preload_archive_indexes)
     yield
 
 
@@ -501,6 +502,8 @@ def get_archive_urls(config):
     urls = []
     archives = config["scope"]["archives"]
     for archive in archives:
+        if "url" not in archive:
+            continue
         url = archive["url"]
         if isinstance(url, list):
             urls += url

--- a/app/main.py
+++ b/app/main.py
@@ -482,8 +482,16 @@ def get_groups_from_archives(config):
 
 def preload_archive_indexes():
     for url in get_archive_urls(config):
-        r = ArchiveIndexRequest(url=url, cache=cache)
-        r.preload()
+        try:
+            r = ArchiveIndexRequest(url=url, cache=cache)
+            r.preload()
+        except ArchiveException as e:
+            print({
+                "message": "Failed to preload archive index",
+                "url": url,
+                "status_code": e.status_code,
+                "detail": e.message
+            })
 
 
 def get_archive_urls(config):

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from .archive import ArchiveIndexRequest, ArchiveException
 from .models import Event, EventDetail, Group
 from .cache import EventRequestCache
 import os
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 import yaml
 from dotenv import load_dotenv
@@ -24,10 +25,18 @@ with open(config_file, "r") as yml:
 
 connpass_api_key = os.getenv("CONNPASS_API_KEY")
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    preload_archive_indexes()
+    yield
+
+
 app = FastAPI(
     title=config["metadata"]["title"],
     description=config["metadata"]["description"],
-    version=config["metadata"]["version"]
+    version=config["metadata"]["version"],
+    lifespan=lifespan
 )
 
 app.add_middleware(
@@ -469,6 +478,12 @@ def get_groups_from_archives(config):
         groups += r.get_groups()
 
     return groups
+
+
+def preload_archive_indexes():
+    for url in get_archive_urls(config):
+        r = ArchiveIndexRequest(url=url, cache=cache)
+        r.preload()
 
 
 def get_archive_urls(config):

--- a/app/main.py
+++ b/app/main.py
@@ -333,9 +333,8 @@ def request_events(params) -> Tuple[List[EventDetail], datetime]:
                 last_modified = max(last_modified, r.get_last_modified())
 
         if "scope" in config and "archives" in config["scope"]:
-            archives = config["scope"]["archives"]
-            for archive in archives:
-                r = ArchiveIndexRequest(url=archive["url"],
+            for url in get_archive_urls(config):
+                r = ArchiveIndexRequest(url=url,
                                         ym=ym, ymd=ymd, cache=cache)
                 events += r.get_events()
                 last_modified = max(last_modified, r.get_last_modified())
@@ -423,9 +422,8 @@ def request_groups(params) -> Tuple[List[Group], datetime]:
             groups += get_groups_from_icalendar(config)
 
         if "scope" in config and "archives" in config["scope"]:
-            archives = config["scope"]["archives"]
-            for archive in archives:
-                r = ArchiveIndexRequest(url=archive["url"], cache=cache)
+            for url in get_archive_urls(config):
+                r = ArchiveIndexRequest(url=url, cache=cache)
                 groups += r.get_groups()
                 last_modified = max(last_modified, r.get_last_modified())
 
@@ -466,10 +464,24 @@ def get_groups_from_icalendar(config):
 
 def get_groups_from_archives(config):
     groups = []
-    if "scope" in config and "archives" in config["scope"]:
-        archives = config["scope"]["archives"]
-        for archive in archives:
-            r = ArchiveIndexRequest(url=archive["url"], cache=cache)
-            groups += r.get_groups()
+    for url in get_archive_urls(config):
+        r = ArchiveIndexRequest(url=url, cache=cache)
+        groups += r.get_groups()
 
     return groups
+
+
+def get_archive_urls(config):
+    if "scope" not in config or "archives" not in config["scope"]:
+        return []
+
+    urls = []
+    archives = config["scope"]["archives"]
+    for archive in archives:
+        url = archive["url"]
+        if isinstance(url, list):
+            urls += url
+        else:
+            urls.append(url)
+
+    return urls

--- a/app/models.py
+++ b/app/models.py
@@ -167,6 +167,8 @@ class Group:
     facebook_url: Optional[str]
     member_users_count: Optional[int]
     ical_url: Optional[str]
+    archive_source: Optional[str] = None
+    archive_url: Optional[str] = None
 
     @staticmethod
     def from_json(data: any):
@@ -187,7 +189,9 @@ class Group:
                 x_username=data.get("x_username"),
                 facebook_url=data.get("facebook_url"),
                 member_users_count=data.get("member_users_count"),
-                ical_url=data.get("ical_url")
+                ical_url=data.get("ical_url"),
+                archive_source=data.get("archive_source"),
+                archive_url=data.get("archive_url")
             )
 
         raise ValueError("data must be Group or List[Group]")
@@ -211,7 +215,9 @@ class Group:
                 "x_username": data.x_username,
                 "facebook_url": data.facebook_url,
                 "member_users_count": data.member_users_count,
-                "ical_url": data.ical_url
+                "ical_url": data.ical_url,
+                "archive_source": data.archive_source,
+                "archive_url": data.archive_url
             }
 
         raise ValueError("data must be Group or List[Group]")

--- a/docs/archive-index.md
+++ b/docs/archive-index.md
@@ -11,7 +11,7 @@ Add `scope.archives` to `app/config.yaml`.
 ```yaml
 scope:
   archives:
-    - url: https://example.github.io/yamanashi-it-event-archive/index.json
+    - url: https://yuukis.github.io/yamanashi-event-archive/index.json
 ```
 
 Multiple archive indexes can be configured.
@@ -19,7 +19,7 @@ Multiple archive indexes can be configured.
 ```yaml
 scope:
   archives:
-    - url: https://example.github.io/yamanashi-it-event-archive/index.json
+    - url: https://yuukis.github.io/yamanashi-event-archive/index.json
     - url: https://example.github.io/another-tech-event-archive/index.json
 ```
 
@@ -35,8 +35,8 @@ The top-level `events` array is converted to `EventDetail`. The top-level
   "generated_at": "2026-06-30T00:00:00+09:00",
   "source": {
     "type": "archive_index",
-    "name": "yamanashi-it-event-archive",
-    "url": "https://github.com/yuukis/yamanashi-it-event-archive",
+    "name": "yamanashi-event-archive",
+    "url": "https://github.com/yuukis/yamanashi-event-archive",
     "ref": "main"
   },
   "communities": [
@@ -53,13 +53,13 @@ The top-level `events` array is converted to `EventDetail`. The top-level
       "facebook_url": null,
       "member_users_count": null,
       "ical_url": null,
-      "archive_source": "yamanashi-it-event-archive",
-      "archive_url": "https://github.com/yuukis/yamanashi-it-event-archive"
+      "archive_source": "yamanashi-event-archive",
+      "archive_url": "https://github.com/yuukis/yamanashi-event-archive"
     }
   ],
   "events": [
     {
-      "uid": "yamanashi-web-2012-05-19-001@yamanashi-it-event-archive",
+      "uid": "yamanashi-web-2012-05-19-001@yamanashi-event-archive",
       "event_id": null,
       "title": "山梨Web勉強会 第1回",
       "catch": "山梨のWeb制作者・開発者が集まる勉強会",
@@ -95,7 +95,7 @@ The top-level `events` array is converted to `EventDetail`. The top-level
 For example:
 
 ```text
-yamanashi-web-2012-05-19-001@yamanashi-it-event-archive
+yamanashi-web-2012-05-19-001@yamanashi-event-archive
 ```
 
 The required event fields are:

--- a/docs/archive-index.md
+++ b/docs/archive-index.md
@@ -5,7 +5,9 @@ outside this API project. The API reads the generated JSON index and merges its
 events with connpass and iCalendar events.
 
 Archive index JSON files are loaded on application startup and kept in memory
-without expiration while the application process is running.
+without expiration while the application process is running. If startup preload
+fails, the application keeps running and retries the archive fetch when an
+archive-backed endpoint is requested.
 
 ## Configuration
 

--- a/docs/archive-index.md
+++ b/docs/archive-index.md
@@ -26,7 +26,8 @@ scope:
 ## JSON Format
 
 The top-level `events` array is converted to `EventDetail`. The top-level
-`communities` array is converted to `Group`.
+`communities` array is converted to `Group`. The API adds `archive_source` and
+`archive_url` to each archive community from `source.name` and `source.url`.
 
 ```json
 {
@@ -51,7 +52,9 @@ The top-level `events` array is converted to `EventDetail`. The top-level
       "x_username": null,
       "facebook_url": null,
       "member_users_count": null,
-      "ical_url": null
+      "ical_url": null,
+      "archive_source": "yamanashi-it-event-archive",
+      "archive_url": "https://github.com/yuukis/yamanashi-it-event-archive"
     }
   ],
   "events": [
@@ -104,4 +107,3 @@ The required event fields are:
 - `ended_at`
 - `updated_at`
 - `open_status`
-

--- a/docs/archive-index.md
+++ b/docs/archive-index.md
@@ -4,6 +4,9 @@ Archive indexes provide historical event data from a repository or static site
 outside this API project. The API reads the generated JSON index and merges its
 events with connpass and iCalendar events.
 
+Archive index JSON files are loaded on application startup and kept in memory
+without expiration while the application process is running.
+
 ## Configuration
 
 Add `scope.archives` to `app/config.yaml`.

--- a/docs/archive-index.md
+++ b/docs/archive-index.md
@@ -1,0 +1,107 @@
+# Archive Index
+
+Archive indexes provide historical event data from a repository or static site
+outside this API project. The API reads the generated JSON index and merges its
+events with connpass and iCalendar events.
+
+## Configuration
+
+Add `scope.archives` to `app/config.yaml`.
+
+```yaml
+scope:
+  archives:
+    - url: https://example.github.io/yamanashi-it-event-archive/index.json
+```
+
+Multiple archive indexes can be configured.
+
+```yaml
+scope:
+  archives:
+    - url: https://example.github.io/yamanashi-it-event-archive/index.json
+    - url: https://example.github.io/another-tech-event-archive/index.json
+```
+
+## JSON Format
+
+The top-level `events` array is converted to `EventDetail`. The top-level
+`communities` array is converted to `Group`.
+
+```json
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-30T00:00:00+09:00",
+  "source": {
+    "type": "archive_index",
+    "name": "yamanashi-it-event-archive",
+    "url": "https://github.com/yuukis/yamanashi-it-event-archive",
+    "ref": "main"
+  },
+  "communities": [
+    {
+      "key": "yamanashi-web",
+      "title": "山梨Web勉強会",
+      "sub_title": "山梨県内のWeb制作者・開発者向け勉強会",
+      "url": "https://example.com/yamanashi-web",
+      "description": "山梨県内でWeb制作・Web開発に関心のある人が集まっていた勉強会です。",
+      "owner_text": null,
+      "image_url": null,
+      "website_url": "https://example.com/yamanashi-web",
+      "x_username": null,
+      "facebook_url": null,
+      "member_users_count": null,
+      "ical_url": null
+    }
+  ],
+  "events": [
+    {
+      "uid": "yamanashi-web-2012-05-19-001@yamanashi-it-event-archive",
+      "event_id": null,
+      "title": "山梨Web勉強会 第1回",
+      "catch": "山梨のWeb制作者・開発者が集まる勉強会",
+      "hash_tag": "yamanashiweb",
+      "event_url": "https://example.com/archive/yamanashi-web/2012-05-19-001",
+      "started_at": "2012-05-19T14:00:00+09:00",
+      "ended_at": "2012-05-19T17:00:00+09:00",
+      "updated_at": "2026-06-30T00:00:00+09:00",
+      "open_status": "close",
+      "limit": null,
+      "accepted": null,
+      "waiting": null,
+      "owner_name": null,
+      "place": "山梨県立図書館",
+      "address": "山梨県甲府市北口2-8-1",
+      "group_key": "yamanashi-web",
+      "group_name": "山梨Web勉強会",
+      "group_url": "https://example.com/yamanashi-web",
+      "description": "山梨Web勉強会の初回イベント。",
+      "lat": null,
+      "lon": null
+    }
+  ]
+}
+```
+
+`uid` should follow the same shape as connpass events:
+
+```text
+{group_key}-{YYYY-MM-DD}-{serial}@{archive_source_key}
+```
+
+For example:
+
+```text
+yamanashi-web-2012-05-19-001@yamanashi-it-event-archive
+```
+
+The required event fields are:
+
+- `uid`
+- `title`
+- `event_url`
+- `started_at`
+- `ended_at`
+- `updated_at`
+- `open_status`
+

--- a/docs/archive-index.md
+++ b/docs/archive-index.md
@@ -11,7 +11,8 @@ Add `scope.archives` to `app/config.yaml`.
 ```yaml
 scope:
   archives:
-    - url: https://yuukis.github.io/yamanashi-event-archive/index.json
+    - url:
+        - https://yuukis.github.io/yamanashi-event-archive/index.json
 ```
 
 Multiple archive indexes can be configured.
@@ -19,8 +20,9 @@ Multiple archive indexes can be configured.
 ```yaml
 scope:
   archives:
-    - url: https://yuukis.github.io/yamanashi-event-archive/index.json
-    - url: https://example.github.io/another-tech-event-archive/index.json
+    - url:
+        - https://yuukis.github.io/yamanashi-event-archive/index.json
+        - https://example.github.io/another-tech-event-archive/index.json
 ```
 
 ## JSON Format

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -115,6 +115,10 @@ class TestArchiveIndexRequest(unittest.TestCase):
 
         self.assertEqual(context.exception.status_code, 404)
         self.assertEqual(context.exception.message, "Failed to fetch archive index")
+        mock_get.assert_called_once_with(
+            "https://example.com/archive/index.json",
+            timeout=10
+        )
 
     def __archive_index(self):
         return {
@@ -149,14 +153,12 @@ class TestArchiveIndexRequest(unittest.TestCase):
             ],
             "events": [
                 {
-                    "uid": "yamanashi-web-2012-05-19-001"
-                    "@yamanashi-event-archive",
+                    "uid": "yamanashi-web-2012-05-19-001@yamanashi-event-archive",
                     "event_id": None,
                     "title": "山梨Web勉強会 第1回",
                     "catch": "山梨のWeb制作者・開発者が集まる勉強会",
                     "hash_tag": "yamanashiweb",
-                    "event_url": "https://example.com/archive/yamanashi-web/"
-                    "2012-05-19-001",
+                    "event_url": "https://example.com/archive/yamanashi-web/2012-05-19-001",
                     "started_at": "2012-05-19T14:00:00+09:00",
                     "ended_at": "2012-05-19T17:00:00+09:00",
                     "updated_at": "2026-06-30T00:00:00+09:00",
@@ -175,12 +177,10 @@ class TestArchiveIndexRequest(unittest.TestCase):
                     "lon": None
                 },
                 {
-                    "uid": "houtoupm-2014-03-08-001"
-                    "@yamanashi-event-archive",
+                    "uid": "houtoupm-2014-03-08-001@yamanashi-event-archive",
                     "event_id": None,
                     "title": "Houtou.pm #1",
-                    "event_url": "https://example.com/archive/houtoupm/"
-                    "2014-03-08-001",
+                    "event_url": "https://example.com/archive/houtoupm/2014-03-08-001",
                     "started_at": "2014-03-08T14:00:00+09:00",
                     "ended_at": "2014-03-08T17:00:00+09:00",
                     "updated_at": "2026-06-30T00:00:00+09:00",

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 from app.archive import ArchiveIndexRequest, ArchiveException
+from app.cache import EventRequestCache
 
 
 class TestArchiveIndexRequest(unittest.TestCase):
@@ -77,6 +78,27 @@ class TestArchiveIndexRequest(unittest.TestCase):
             groups[0].archive_url,
             "https://github.com/yuukis/yamanashi-event-archive"
         )
+
+    @patch("app.archive.requests.get")
+    def test_preload_keeps_archive_index_in_cache(self, mock_get):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = self.__archive_index()
+        mock_get.return_value = response
+
+        cache = EventRequestCache(prefix="test_archive_")
+        archive_request = ArchiveIndexRequest(
+            url="https://example.com/archive/index.json",
+            cache=cache
+        )
+
+        archive_request.preload()
+        events = archive_request.get_events()
+        groups = archive_request.get_groups()
+
+        self.assertEqual(len(events), 2)
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(mock_get.call_count, 1)
 
     @patch("app.archive.requests.get")
     def test_get_events_http_error(self, mock_get):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,169 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from app.archive import ArchiveIndexRequest, ArchiveException
+
+
+class TestArchiveIndexRequest(unittest.TestCase):
+    def test_get_events(self):
+        archive_request = ArchiveIndexRequest(
+            url="https://example.com/archive/index.json"
+        )
+        archive_request._ArchiveIndexRequest__get_json = MagicMock(
+            return_value=self.__archive_index()
+        )
+
+        events = archive_request.get_events()
+
+        self.assertEqual(len(events), 2)
+        self.assertEqual(
+            events[0].uid,
+            "yamanashi-web-2012-05-19-001@yamanashi-it-event-archive"
+        )
+        self.assertEqual(events[0].event_id, None)
+        self.assertEqual(events[0].group_key, "yamanashi-web")
+
+    def test_get_events_by_ym(self):
+        archive_request = ArchiveIndexRequest(
+            url="https://example.com/archive/index.json",
+            ym=["201205"]
+        )
+        archive_request._ArchiveIndexRequest__get_json = MagicMock(
+            return_value=self.__archive_index()
+        )
+
+        events = archive_request.get_events()
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(
+            events[0].uid,
+            "yamanashi-web-2012-05-19-001@yamanashi-it-event-archive"
+        )
+
+    def test_get_events_by_ymd(self):
+        archive_request = ArchiveIndexRequest(
+            url="https://example.com/archive/index.json",
+            ymd=["20140308"]
+        )
+        archive_request._ArchiveIndexRequest__get_json = MagicMock(
+            return_value=self.__archive_index()
+        )
+
+        events = archive_request.get_events()
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(
+            events[0].uid,
+            "houtoupm-2014-03-08-001@yamanashi-it-event-archive"
+        )
+
+    def test_get_groups(self):
+        archive_request = ArchiveIndexRequest(
+            url="https://example.com/archive/index.json"
+        )
+        archive_request._ArchiveIndexRequest__get_json = MagicMock(
+            return_value=self.__archive_index()
+        )
+
+        groups = archive_request.get_groups()
+
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(groups[0].key, "yamanashi-web")
+        self.assertEqual(groups[0].title, "山梨Web勉強会")
+        self.assertEqual(groups[0].url, "https://example.com/yamanashi-web")
+        self.assertEqual(groups[0].ical_url, None)
+
+    @patch("app.archive.requests.get")
+    def test_get_events_http_error(self, mock_get):
+        response = MagicMock()
+        response.status_code = 404
+        mock_get.return_value = response
+
+        archive_request = ArchiveIndexRequest(
+            url="https://example.com/archive/index.json"
+        )
+
+        with self.assertRaises(ArchiveException) as context:
+            archive_request.get_events()
+
+        self.assertEqual(context.exception.status_code, 404)
+        self.assertEqual(context.exception.message, "Failed to fetch archive index")
+
+    def __archive_index(self):
+        return {
+            "schema_version": "1.0",
+            "generated_at": "2026-06-30T00:00:00+09:00",
+            "source": {
+                "type": "archive_index",
+                "name": "yamanashi-it-event-archive",
+                "url": "https://github.com/yuukis/yamanashi-it-event-archive",
+                "ref": "main"
+            },
+            "communities": [
+                {
+                    "key": "yamanashi-web",
+                    "title": "山梨Web勉強会",
+                    "sub_title": "山梨県内のWeb制作者・開発者向け勉強会",
+                    "url": "https://example.com/yamanashi-web",
+                    "description": "山梨県内のWeb制作・Web開発勉強会です。",
+                    "owner_text": None,
+                    "image_url": None,
+                    "website_url": "https://example.com/yamanashi-web",
+                    "x_username": None,
+                    "facebook_url": None,
+                    "member_users_count": None,
+                    "ical_url": None
+                },
+                {
+                    "key": "houtoupm",
+                    "title": "Houtou.pm",
+                    "url": "https://example.com/houtoupm"
+                }
+            ],
+            "events": [
+                {
+                    "uid": "yamanashi-web-2012-05-19-001"
+                    "@yamanashi-it-event-archive",
+                    "event_id": None,
+                    "title": "山梨Web勉強会 第1回",
+                    "catch": "山梨のWeb制作者・開発者が集まる勉強会",
+                    "hash_tag": "yamanashiweb",
+                    "event_url": "https://example.com/archive/yamanashi-web/"
+                    "2012-05-19-001",
+                    "started_at": "2012-05-19T14:00:00+09:00",
+                    "ended_at": "2012-05-19T17:00:00+09:00",
+                    "updated_at": "2026-06-30T00:00:00+09:00",
+                    "open_status": "close",
+                    "limit": None,
+                    "accepted": None,
+                    "waiting": None,
+                    "owner_name": None,
+                    "place": "山梨県立図書館",
+                    "address": "山梨県甲府市北口2-8-1",
+                    "group_key": "yamanashi-web",
+                    "group_name": "山梨Web勉強会",
+                    "group_url": "https://example.com/yamanashi-web",
+                    "description": "山梨Web勉強会の初回イベント。",
+                    "lat": None,
+                    "lon": None
+                },
+                {
+                    "uid": "houtoupm-2014-03-08-001"
+                    "@yamanashi-it-event-archive",
+                    "event_id": None,
+                    "title": "Houtou.pm #1",
+                    "event_url": "https://example.com/archive/houtoupm/"
+                    "2014-03-08-001",
+                    "started_at": "2014-03-08T14:00:00+09:00",
+                    "ended_at": "2014-03-08T17:00:00+09:00",
+                    "updated_at": "2026-06-30T00:00:00+09:00",
+                    "open_status": "close",
+                    "group_key": "houtoupm",
+                    "group_name": "Houtou.pm",
+                    "group_url": "https://example.com/houtoupm"
+                }
+            ]
+        }
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -17,7 +17,7 @@ class TestArchiveIndexRequest(unittest.TestCase):
         self.assertEqual(len(events), 2)
         self.assertEqual(
             events[0].uid,
-            "yamanashi-web-2012-05-19-001@yamanashi-it-event-archive"
+            "yamanashi-web-2012-05-19-001@yamanashi-event-archive"
         )
         self.assertEqual(events[0].event_id, None)
         self.assertEqual(events[0].group_key, "yamanashi-web")
@@ -36,7 +36,7 @@ class TestArchiveIndexRequest(unittest.TestCase):
         self.assertEqual(len(events), 1)
         self.assertEqual(
             events[0].uid,
-            "yamanashi-web-2012-05-19-001@yamanashi-it-event-archive"
+            "yamanashi-web-2012-05-19-001@yamanashi-event-archive"
         )
 
     def test_get_events_by_ymd(self):
@@ -53,7 +53,7 @@ class TestArchiveIndexRequest(unittest.TestCase):
         self.assertEqual(len(events), 1)
         self.assertEqual(
             events[0].uid,
-            "houtoupm-2014-03-08-001@yamanashi-it-event-archive"
+            "houtoupm-2014-03-08-001@yamanashi-event-archive"
         )
 
     def test_get_groups(self):
@@ -72,10 +72,10 @@ class TestArchiveIndexRequest(unittest.TestCase):
         self.assertEqual(groups[0].url, "https://example.com/yamanashi-web")
         self.assertEqual(groups[0].ical_url, None)
         self.assertEqual(groups[0].archive_source,
-                         "yamanashi-it-event-archive")
+                         "yamanashi-event-archive")
         self.assertEqual(
             groups[0].archive_url,
-            "https://github.com/yuukis/yamanashi-it-event-archive"
+            "https://github.com/yuukis/yamanashi-event-archive"
         )
 
     @patch("app.archive.requests.get")
@@ -100,8 +100,8 @@ class TestArchiveIndexRequest(unittest.TestCase):
             "generated_at": "2026-06-30T00:00:00+09:00",
             "source": {
                 "type": "archive_index",
-                "name": "yamanashi-it-event-archive",
-                "url": "https://github.com/yuukis/yamanashi-it-event-archive",
+                "name": "yamanashi-event-archive",
+                "url": "https://github.com/yuukis/yamanashi-event-archive",
                 "ref": "main"
             },
             "communities": [
@@ -128,7 +128,7 @@ class TestArchiveIndexRequest(unittest.TestCase):
             "events": [
                 {
                     "uid": "yamanashi-web-2012-05-19-001"
-                    "@yamanashi-it-event-archive",
+                    "@yamanashi-event-archive",
                     "event_id": None,
                     "title": "山梨Web勉強会 第1回",
                     "catch": "山梨のWeb制作者・開発者が集まる勉強会",
@@ -154,7 +154,7 @@ class TestArchiveIndexRequest(unittest.TestCase):
                 },
                 {
                     "uid": "houtoupm-2014-03-08-001"
-                    "@yamanashi-it-event-archive",
+                    "@yamanashi-event-archive",
                     "event_id": None,
                     "title": "Houtou.pm #1",
                     "event_url": "https://example.com/archive/houtoupm/"

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -71,6 +71,12 @@ class TestArchiveIndexRequest(unittest.TestCase):
         self.assertEqual(groups[0].title, "山梨Web勉強会")
         self.assertEqual(groups[0].url, "https://example.com/yamanashi-web")
         self.assertEqual(groups[0].ical_url, None)
+        self.assertEqual(groups[0].archive_source,
+                         "yamanashi-it-event-archive")
+        self.assertEqual(
+            groups[0].archive_url,
+            "https://github.com/yuukis/yamanashi-it-event-archive"
+        )
 
     @patch("app.archive.requests.get")
     def test_get_events_http_error(self, mock_get):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -78,6 +78,19 @@ class TestEventRequestCache(unittest.TestCase):
         self.assertEqual(self.cache._store[expected_last_modified], 123)
         self.assertIn(expected_last_modified, self.cache._expiry)
 
+    def test_set_without_expiry(self):
+        self.cache._store = {}
+        self.cache._expiry = {}
+
+        dt = datetime.fromtimestamp(123, timezone.utc)
+
+        self.cache.set({"param": "value"}, {"key": "value"}, last_modified=dt,
+                       ex=None)
+
+        response = self.cache.get({"param": "value"})
+        self.assertEqual(response["json"], {"key": "value"})
+        self.assertEqual(response["last_modified"], dt)
+
     def test_generate_key(self):
         params = {"param": "value"}
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 from app.main import app, get_user_agent, get_groups_from_icalendar
 from app.main import request_events, request_groups, get_groups_from_archives
-from app.main import get_archive_urls
+from app.main import get_archive_urls, preload_archive_indexes
 from app.cache import EventRequestCache
 from app.models import EventDetail, Group
 from datetime import datetime, timezone
@@ -144,6 +144,7 @@ class MockICalEventRequest:
 
 class MockArchiveIndexRequest:
     requested_urls = []
+    preloaded_urls = []
 
     def __init__(self, **kwargs):
         self.url = kwargs.get("url")
@@ -206,10 +207,14 @@ class MockArchiveIndexRequest:
         last_modified = datetime.fromtimestamp(123, timezone.utc)
         return last_modified
 
+    def preload(self):
+        MockArchiveIndexRequest.preloaded_urls.append(self.url)
+
 
 @pytest.fixture(autouse=True)
 def mock_archive_index_request():
     MockArchiveIndexRequest.requested_urls = []
+    MockArchiveIndexRequest.preloaded_urls = []
     with patch("app.main.ArchiveIndexRequest", MockArchiveIndexRequest):
         yield
 
@@ -539,4 +544,26 @@ def test_get_archive_urls():
         "https://example.com/archive/index-1.json",
         "https://example.com/archive/index-2.json",
         "https://example.com/archive/index-3.json"
+    ]
+
+
+@patch("app.main.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "archives": [
+            {
+                "url": [
+                    "https://example.com/archive/index-1.json",
+                    "https://example.com/archive/index-2.json"
+                ]
+            }
+        ]
+    }
+})
+def test_preload_archive_indexes():
+    preload_archive_indexes()
+
+    assert MockArchiveIndexRequest.preloaded_urls == [
+        "https://example.com/archive/index-1.json",
+        "https://example.com/archive/index-2.json"
     ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from unittest.mock import patch
 from app.main import app, get_user_agent, get_groups_from_icalendar
 from app.main import request_events, request_groups, get_groups_from_archives
+from app.cache import EventRequestCache
 from app.models import EventDetail, Group
 from datetime import datetime, timezone
 
@@ -188,7 +189,10 @@ class MockArchiveIndexRequest:
                 "x_username": None,
                 "facebook_url": None,
                 "member_users_count": None,
-                "ical_url": None
+                "ical_url": None,
+                "archive_source": "yamanashi-it-event-archive",
+                "archive_url": "https://github.com/yuukis/"
+                "yamanashi-it-event-archive"
             }
         ]
         return Group.from_json(json)
@@ -330,6 +334,36 @@ def test_read_group(mock_get_groups_from_icalendar):
     assert isinstance(response.json(), list)
 
 
+@patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.main.get_groups_from_icalendar")
+@patch("app.main.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "subdomain": ["test"],
+        "archives": [
+            {
+                "url": "https://example.com/archive/index.json"
+            }
+        ]
+    }
+})
+@patch("app.main.ArchiveIndexRequest", MockArchiveIndexRequest)
+@patch("app.main.cache", EventRequestCache(prefix="test_archive_group_"))
+def test_read_group_includes_archive_source(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/groups")
+
+    assert response.status_code == 200
+    archive_group = [
+        group for group in response.json()
+        if group["key"] == "yamanashi-web"
+    ][0]
+    assert archive_group["archive_source"] == "yamanashi-it-event-archive"
+    assert archive_group["archive_url"] == \
+        "https://github.com/yuukis/yamanashi-it-event-archive"
+
+
 def test_get_user_agent():
     config = {
         "metadata": {
@@ -419,6 +453,9 @@ def test_request_groups_from_archives():
     assert len(groups) == 1
     assert groups[0].key == "yamanashi-web"
     assert groups[0].title == "山梨Web勉強会"
+    assert groups[0].archive_source == "yamanashi-it-event-archive"
+    assert groups[0].archive_url == \
+        "https://github.com/yuukis/yamanashi-it-event-archive"
     assert last_modified == datetime.fromtimestamp(123, timezone.utc)
 
 
@@ -438,3 +475,6 @@ def test_get_groups_from_archives():
 
     assert len(groups) == 1
     assert groups[0].key == "yamanashi-web"
+    assert groups[0].archive_source == "yamanashi-it-event-archive"
+    assert groups[0].archive_url == \
+        "https://github.com/yuukis/yamanashi-it-event-archive"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 from unittest.mock import patch
+import pytest
 from app.main import app, get_user_agent, get_groups_from_icalendar
 from app.main import request_events, request_groups, get_groups_from_archives
 from app.cache import EventRequestCache
@@ -148,7 +149,7 @@ class MockArchiveIndexRequest:
         json = [
             {
                 "uid": "yamanashi-web-2012-05-19-001"
-                "@yamanashi-it-event-archive",
+                "@yamanashi-event-archive",
                 "event_id": None,
                 "title": "山梨Web勉強会 第1回",
                 "catch": "山梨のWeb制作者・開発者が集まる勉強会",
@@ -190,9 +191,9 @@ class MockArchiveIndexRequest:
                 "facebook_url": None,
                 "member_users_count": None,
                 "ical_url": None,
-                "archive_source": "yamanashi-it-event-archive",
+                "archive_source": "yamanashi-event-archive",
                 "archive_url": "https://github.com/yuukis/"
-                "yamanashi-it-event-archive"
+                "yamanashi-event-archive"
             }
         ]
         return Group.from_json(json)
@@ -200,6 +201,12 @@ class MockArchiveIndexRequest:
     def get_last_modified(self):
         last_modified = datetime.fromtimestamp(123, timezone.utc)
         return last_modified
+
+
+@pytest.fixture(autouse=True)
+def mock_archive_index_request():
+    with patch("app.main.ArchiveIndexRequest", MockArchiveIndexRequest):
+        yield
 
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
@@ -359,9 +366,9 @@ def test_read_group_includes_archive_source(mock_get_groups_from_icalendar):
         group for group in response.json()
         if group["key"] == "yamanashi-web"
     ][0]
-    assert archive_group["archive_source"] == "yamanashi-it-event-archive"
+    assert archive_group["archive_source"] == "yamanashi-event-archive"
     assert archive_group["archive_url"] == \
-        "https://github.com/yuukis/yamanashi-it-event-archive"
+        "https://github.com/yuukis/yamanashi-event-archive"
 
 
 def test_get_user_agent():
@@ -431,7 +438,7 @@ def test_request_events_from_archives():
 
     assert len(events) == 1
     assert events[0].uid == \
-        "yamanashi-web-2012-05-19-001@yamanashi-it-event-archive"
+        "yamanashi-web-2012-05-19-001@yamanashi-event-archive"
     assert events[0].group_key == "yamanashi-web"
     assert last_modified == datetime.fromtimestamp(123, timezone.utc)
 
@@ -453,9 +460,9 @@ def test_request_groups_from_archives():
     assert len(groups) == 1
     assert groups[0].key == "yamanashi-web"
     assert groups[0].title == "山梨Web勉強会"
-    assert groups[0].archive_source == "yamanashi-it-event-archive"
+    assert groups[0].archive_source == "yamanashi-event-archive"
     assert groups[0].archive_url == \
-        "https://github.com/yuukis/yamanashi-it-event-archive"
+        "https://github.com/yuukis/yamanashi-event-archive"
     assert last_modified == datetime.fromtimestamp(123, timezone.utc)
 
 
@@ -475,6 +482,6 @@ def test_get_groups_from_archives():
 
     assert len(groups) == 1
     assert groups[0].key == "yamanashi-web"
-    assert groups[0].archive_source == "yamanashi-it-event-archive"
+    assert groups[0].archive_source == "yamanashi-event-archive"
     assert groups[0].archive_url == \
-        "https://github.com/yuukis/yamanashi-it-event-archive"
+        "https://github.com/yuukis/yamanashi-event-archive"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -154,14 +154,12 @@ class MockArchiveIndexRequest:
     def get_events(self):
         json = [
             {
-                "uid": "yamanashi-web-2012-05-19-001"
-                "@yamanashi-event-archive",
+                "uid": "yamanashi-web-2012-05-19-001@yamanashi-event-archive",
                 "event_id": None,
                 "title": "山梨Web勉強会 第1回",
                 "catch": "山梨のWeb制作者・開発者が集まる勉強会",
                 "hash_tag": "yamanashiweb",
-                "event_url": "https://example.com/archive/yamanashi-web/"
-                "2012-05-19-001",
+                "event_url": "https://example.com/archive/yamanashi-web/2012-05-19-001",
                 "started_at": "2012-05-19T14:00:00+09:00",
                 "ended_at": "2012-05-19T17:00:00+09:00",
                 "updated_at": "2026-06-30T00:00:00+09:00",
@@ -198,8 +196,7 @@ class MockArchiveIndexRequest:
                 "member_users_count": None,
                 "ical_url": None,
                 "archive_source": "yamanashi-event-archive",
-                "archive_url": "https://github.com/yuukis/"
-                "yamanashi-event-archive"
+                "archive_url": "https://github.com/yuukis/yamanashi-event-archive"
             }
         ]
         return Group.from_json(json)
@@ -539,6 +536,9 @@ def test_get_archive_urls():
                         "https://example.com/archive/index-1.json",
                         "https://example.com/archive/index-2.json"
                     ]
+                },
+                {
+                    "name": "missing url"
                 },
                 {
                     "url": "https://example.com/archive/index-3.json"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 from app.main import app, get_user_agent, get_groups_from_icalendar
 from app.main import request_events, request_groups, get_groups_from_archives
+from app.main import get_archive_urls
 from app.cache import EventRequestCache
 from app.models import EventDetail, Group
 from datetime import datetime, timezone
@@ -142,8 +143,11 @@ class MockICalEventRequest:
 
 
 class MockArchiveIndexRequest:
+    requested_urls = []
+
     def __init__(self, **kwargs):
-        pass
+        self.url = kwargs.get("url")
+        MockArchiveIndexRequest.requested_urls.append(self.url)
 
     def get_events(self):
         json = [
@@ -205,6 +209,7 @@ class MockArchiveIndexRequest:
 
 @pytest.fixture(autouse=True)
 def mock_archive_index_request():
+    MockArchiveIndexRequest.requested_urls = []
     with patch("app.main.ArchiveIndexRequest", MockArchiveIndexRequest):
         yield
 
@@ -443,6 +448,30 @@ def test_request_events_from_archives():
     assert last_modified == datetime.fromtimestamp(123, timezone.utc)
 
 
+@patch("app.main.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "archives": [
+            {
+                "url": [
+                    "https://example.com/archive/index-1.json",
+                    "https://example.com/archive/index-2.json"
+                ]
+            }
+        ]
+    }
+})
+def test_request_events_from_archive_urls():
+    events, last_modified = request_events({})
+
+    assert len(events) == 1
+    assert last_modified == datetime.fromtimestamp(123, timezone.utc)
+    assert MockArchiveIndexRequest.requested_urls == [
+        "https://example.com/archive/index-1.json",
+        "https://example.com/archive/index-2.json"
+    ]
+
+
 @patch("app.main.ArchiveIndexRequest", MockArchiveIndexRequest)
 @patch("app.main.config", {
     "metadata": {"version": "1.0.0"},
@@ -485,3 +514,29 @@ def test_get_groups_from_archives():
     assert groups[0].archive_source == "yamanashi-event-archive"
     assert groups[0].archive_url == \
         "https://github.com/yuukis/yamanashi-event-archive"
+
+
+def test_get_archive_urls():
+    config = {
+        "scope": {
+            "archives": [
+                {
+                    "url": [
+                        "https://example.com/archive/index-1.json",
+                        "https://example.com/archive/index-2.json"
+                    ]
+                },
+                {
+                    "url": "https://example.com/archive/index-3.json"
+                }
+            ]
+        }
+    }
+
+    urls = get_archive_urls(config)
+
+    assert urls == [
+        "https://example.com/archive/index-1.json",
+        "https://example.com/archive/index-2.json",
+        "https://example.com/archive/index-3.json"
+    ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,7 @@ from app.main import app, get_user_agent, get_groups_from_icalendar
 from app.main import request_events, request_groups, get_groups_from_archives
 from app.main import get_archive_urls, preload_archive_indexes
 from app.cache import EventRequestCache
+from app.archive import ArchiveException
 from app.models import EventDetail, Group
 from datetime import datetime, timezone
 
@@ -209,6 +210,14 @@ class MockArchiveIndexRequest:
 
     def preload(self):
         MockArchiveIndexRequest.preloaded_urls.append(self.url)
+
+
+class MockFailingPreloadArchiveIndexRequest:
+    def __init__(self, **kwargs):
+        self.url = kwargs.get("url")
+
+    def preload(self):
+        raise ArchiveException(500, "Failed to fetch archive index")
 
 
 @pytest.fixture(autouse=True)
@@ -567,3 +576,21 @@ def test_preload_archive_indexes():
         "https://example.com/archive/index-1.json",
         "https://example.com/archive/index-2.json"
     ]
+
+
+@patch("app.main.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "archives": [
+            {
+                "url": [
+                    "https://example.com/archive/index-1.json"
+                ]
+            }
+        ]
+    }
+})
+def test_preload_archive_indexes_does_not_raise_on_error():
+    with patch("app.main.ArchiveIndexRequest",
+               MockFailingPreloadArchiveIndexRequest):
+        preload_archive_indexes()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 from app.main import app, get_user_agent, get_groups_from_icalendar
+from app.main import request_events, request_groups, get_groups_from_archives
 from app.models import EventDetail, Group
 from datetime import datetime, timezone
 
@@ -132,6 +133,65 @@ class MockICalEventRequest:
         ]
         events = EventDetail.from_json(json)
         return events
+
+    def get_last_modified(self):
+        last_modified = datetime.fromtimestamp(123, timezone.utc)
+        return last_modified
+
+
+class MockArchiveIndexRequest:
+    def __init__(self, **kwargs):
+        pass
+
+    def get_events(self):
+        json = [
+            {
+                "uid": "yamanashi-web-2012-05-19-001"
+                "@yamanashi-it-event-archive",
+                "event_id": None,
+                "title": "山梨Web勉強会 第1回",
+                "catch": "山梨のWeb制作者・開発者が集まる勉強会",
+                "hash_tag": "yamanashiweb",
+                "event_url": "https://example.com/archive/yamanashi-web/"
+                "2012-05-19-001",
+                "started_at": "2012-05-19T14:00:00+09:00",
+                "ended_at": "2012-05-19T17:00:00+09:00",
+                "updated_at": "2026-06-30T00:00:00+09:00",
+                "open_status": "close",
+                "limit": None,
+                "accepted": None,
+                "waiting": None,
+                "owner_name": None,
+                "place": "山梨県立図書館",
+                "address": "山梨県甲府市北口2-8-1",
+                "group_key": "yamanashi-web",
+                "group_name": "山梨Web勉強会",
+                "group_url": "https://example.com/yamanashi-web",
+                "description": "山梨Web勉強会の初回イベント。",
+                "lat": None,
+                "lon": None
+            }
+        ]
+        return EventDetail.from_json(json)
+
+    def get_groups(self):
+        json = [
+            {
+                "key": "yamanashi-web",
+                "title": "山梨Web勉強会",
+                "sub_title": "山梨県内のWeb制作者・開発者向け勉強会",
+                "url": "https://example.com/yamanashi-web",
+                "description": "山梨県内のWeb制作・Web開発勉強会です。",
+                "owner_text": None,
+                "image_url": None,
+                "website_url": "https://example.com/yamanashi-web",
+                "x_username": None,
+                "facebook_url": None,
+                "member_users_count": None,
+                "ical_url": None
+            }
+        ]
+        return Group.from_json(json)
 
     def get_last_modified(self):
         last_modified = datetime.fromtimestamp(123, timezone.utc)
@@ -319,3 +379,62 @@ def test_get_groups_from_icalendar():
     assert groups[1].image_url is None
     assert groups[1].ical_url == "http://example.com/ical"
     assert groups[1].description is None
+
+
+@patch("app.main.ArchiveIndexRequest", MockArchiveIndexRequest)
+@patch("app.main.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "archives": [
+            {
+                "url": "https://example.com/archive/index.json"
+            }
+        ]
+    }
+})
+def test_request_events_from_archives():
+    events, last_modified = request_events({"ym": ["201205"]})
+
+    assert len(events) == 1
+    assert events[0].uid == \
+        "yamanashi-web-2012-05-19-001@yamanashi-it-event-archive"
+    assert events[0].group_key == "yamanashi-web"
+    assert last_modified == datetime.fromtimestamp(123, timezone.utc)
+
+
+@patch("app.main.ArchiveIndexRequest", MockArchiveIndexRequest)
+@patch("app.main.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "archives": [
+            {
+                "url": "https://example.com/archive/index.json"
+            }
+        ]
+    }
+})
+def test_request_groups_from_archives():
+    groups, last_modified = request_groups({})
+
+    assert len(groups) == 1
+    assert groups[0].key == "yamanashi-web"
+    assert groups[0].title == "山梨Web勉強会"
+    assert last_modified == datetime.fromtimestamp(123, timezone.utc)
+
+
+@patch("app.main.ArchiveIndexRequest", MockArchiveIndexRequest)
+def test_get_groups_from_archives():
+    config = {
+        "scope": {
+            "archives": [
+                {
+                    "url": "https://example.com/archive/index.json"
+                }
+            ]
+        }
+    }
+
+    groups = get_groups_from_archives(config)
+
+    assert len(groups) == 1
+    assert groups[0].key == "yamanashi-web"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -220,7 +220,9 @@ class TestGroup(unittest.TestCase):
             "x_username": "X Username",
             "facebook_url": "Facebook URL",
             "member_users_count": 100,
-            "ical_url": "iCal URL"
+            "ical_url": "iCal URL",
+            "archive_source": "Archive Source",
+            "archive_url": "Archive URL"
         }
 
         # Call the from_json method
@@ -241,6 +243,8 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(group.facebook_url, "Facebook URL")
         self.assertEqual(group.member_users_count, 100)
         self.assertEqual(group.ical_url, "iCal URL")
+        self.assertEqual(group.archive_source, "Archive Source")
+        self.assertEqual(group.archive_url, "Archive URL")
 
     def test_to_json_with_list(self):
         # Create a list of group objects
@@ -249,12 +253,16 @@ class TestGroup(unittest.TestCase):
                   url="URL", description="Description", owner_text="Owner Text",
                   image_url="Image URL", website_url="Website URL",
                   x_username="X Username", facebook_url="Facebook URL",
-                  member_users_count=100, ical_url="iCal URL"),
+                  member_users_count=100, ical_url="iCal URL",
+                  archive_source="Archive Source",
+                  archive_url="Archive URL"),
             Group(id=2, key="Key", title="Title", sub_title="Sub Title",
                   url="URL", description="Description", owner_text="Owner Text",
                   image_url="Image URL", website_url="Website URL",
                   x_username="X Username", facebook_url="Facebook URL",
-                  member_users_count=100, ical_url="iCal URL")
+                  member_users_count=100, ical_url="iCal URL",
+                  archive_source="Archive Source",
+                  archive_url="Archive URL")
         ]
 
         # Call the to_json method
@@ -265,6 +273,8 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(len(data), 2)
         self.assertEqual(data[0]["id"], 1)
         self.assertEqual(data[1]["id"], 2)
+        self.assertEqual(data[0]["archive_source"], "Archive Source")
+        self.assertEqual(data[0]["archive_url"], "Archive URL")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 概要
- 外部 archive index JSON をイベント・グループのデータソースとして読み込めるようにしました
- 山梨イベントアーカイブの index.json を設定に追加しました
- /groups で archive_source / archive_url を返却できるようにしました
- archive index はアプリ起動時に先読みし、起動中はメモリに保持します
- 起動時の先読み失敗時はログ出力のみ行い、リクエスト時に再取得を試みます

## テスト
- .venv/bin/python -m pytest
