### PR TITLE
Add MCP server support via fastapi-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,31 @@ If you have Docker and Docker Compose installed, you can use the following steps
 
 See [API document](https://yuukis.github.io/yamanashi-event-api) for more details.
 
+## MCP Server
+
+This API also exposes an [MCP](https://modelcontextprotocol.io) server at
+`/mcp` (Streamable HTTP transport), so MCP-compatible clients (e.g. Claude,
+Claude Code) can call it as tools instead of plain HTTP requests.
+
+```sh
+claude mcp add --transport http yamanashi-event-api http://localhost:8000/mcp
+```
+
+Only the full-detail event operations (e.g. `list_events_full`,
+`list_events_full_by_day`) and `list_groups` are exposed as MCP tools, so
+that the `description` field is always present in tool results. The
+compact `/events` endpoints remain REST-only.
+
+You can try it out interactively with
+[MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```sh
+npx @modelcontextprotocol/inspector
+```
+
+Connect with Transport Type `Streamable HTTP` and URL
+`http://localhost:8000/mcp`.
+
 ## Event Keywords
 
 Each event in the response contains a `keywords` field with up to 5 normalized

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 import yaml
 from dotenv import load_dotenv
 from mangum import Mangum
+from fastapi_mcp import FastApiMCP
 
 load_dotenv()
 dirname = os.path.dirname(__file__)
@@ -276,6 +277,10 @@ async def read_groups(
         response.headers["Last-Modified"] = last_modified_str
         response.headers["Cache-Control"] = "public, max-age=3600"
     return groups
+
+
+mcp = FastApiMCP(app)
+mcp.mount_http()
 
 
 def get_events(params,

--- a/app/main.py
+++ b/app/main.py
@@ -279,7 +279,15 @@ async def read_groups(
     return groups
 
 
-mcp = FastApiMCP(app)
+mcp = FastApiMCP(app, include_operations=[
+    "list_events_full",
+    "list_events_full_today",
+    "list_events_full_by_year",
+    "list_events_full_by_month",
+    "list_events_full_by_day",
+    "list_events_full_by_range",
+    "list_groups",
+])
 mcp.mount_http()
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -58,7 +58,9 @@ def docs_redirect():
     return RedirectResponse(url="/docs")
 
 
-@app.get("/events", response_model=List[Event])
+@app.get("/events", response_model=List[Event],
+         operation_id="list_events",
+         summary="List recent events")
 async def read_events(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -74,7 +76,9 @@ async def read_events(
                                                keyword)
 
 
-@app.get("/events/today", response_model=List[Event])
+@app.get("/events/today", response_model=List[Event],
+         operation_id="list_events_today",
+         summary="List today's events")
 async def read_events_today(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -86,7 +90,9 @@ async def read_events_today(
                                                now.day, keyword)
 
 
-@app.get("/events/in/{year}", response_model=List[Event])
+@app.get("/events/in/{year}", response_model=List[Event],
+         operation_id="list_events_by_year",
+         summary="List events in a specific year")
 async def read_events_in_year(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -98,7 +104,9 @@ async def read_events_in_year(
                                                keyword)
 
 
-@app.get("/events/in/{year}/{month}", response_model=List[Event])
+@app.get("/events/in/{year}/{month}", response_model=List[Event],
+         operation_id="list_events_by_month",
+         summary="List events in a specific year and month")
 async def read_events_in_year_month(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -111,7 +119,9 @@ async def read_events_in_year_month(
                                                keyword)
 
 
-@app.get("/events/in/{year}/{month}/{day}", response_model=List[Event])
+@app.get("/events/in/{year}/{month}/{day}", response_model=List[Event],
+         operation_id="list_events_by_day",
+         summary="List events on a specific day")
 async def read_events_in_year_month_day(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -132,7 +142,9 @@ async def read_events_in_year_month_day(
 
 
 @app.get("/events/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
-         response_model=List[Event])
+         response_model=List[Event],
+         operation_id="list_events_by_range",
+         summary="List events within a date range")
 async def read_events_fromto_year_month(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -167,7 +179,9 @@ async def read_events_fromto_year_month(
     return events
 
 
-@app.get("/events/full", response_model=List[EventDetail])
+@app.get("/events/full", response_model=List[EventDetail],
+         operation_id="list_events_full",
+         summary="List recent events with full details")
 async def read_events_full(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -176,7 +190,9 @@ async def read_events_full(
     return await read_events(response, background_tasks, keyword)
 
 
-@app.get("/events/full/today", response_model=List[EventDetail])
+@app.get("/events/full/today", response_model=List[EventDetail],
+         operation_id="list_events_full_today",
+         summary="List today's events with full details")
 async def read_events_full_today(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -185,7 +201,9 @@ async def read_events_full_today(
     return await read_events_today(response, background_tasks, keyword)
 
 
-@app.get("/events/full/in/{year}", response_model=List[EventDetail])
+@app.get("/events/full/in/{year}", response_model=List[EventDetail],
+         operation_id="list_events_full_by_year",
+         summary="List events in a specific year with full details")
 async def read_events_full_in_year(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -195,7 +213,9 @@ async def read_events_full_in_year(
     return await read_events_in_year(response, background_tasks, year, keyword)
 
 
-@app.get("/events/full/in/{year}/{month}", response_model=List[EventDetail])
+@app.get("/events/full/in/{year}/{month}", response_model=List[EventDetail],
+         operation_id="list_events_full_by_month",
+         summary="List events in a specific year and month with full details")
 async def read_events_full_in_year_month(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -208,7 +228,9 @@ async def read_events_full_in_year_month(
 
 
 @app.get("/events/full/in/{year}/{month}/{day}",
-         response_model=List[EventDetail])
+         response_model=List[EventDetail],
+         operation_id="list_events_full_by_day",
+         summary="List events on a specific day with full details")
 async def read_events_full_in_year_month_day(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -222,7 +244,9 @@ async def read_events_full_in_year_month_day(
 
 
 @app.get("/events/full/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
-         response_model=List[EventDetail])
+         response_model=List[EventDetail],
+         operation_id="list_events_full_by_range",
+         summary="List events within a date range with full details")
 async def read_events_full_fromto_year_month(
     response: Response,
     background_tasks: BackgroundTasks,
@@ -238,7 +262,9 @@ async def read_events_full_fromto_year_month(
                                                keyword)
 
 
-@app.get("/groups", response_model=List[Group])
+@app.get("/groups", response_model=List[Group],
+         operation_id="list_groups",
+         summary="List community groups")
 async def read_groups(
     response: Response,
     background_tasks: BackgroundTasks

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv
 pytest
 httpx
 mangum
+fastapi-mcp

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ python-dotenv
 pytest
 httpx
 mangum
-fastapi-mcp
+fastapi-mcp>=0.4.0


### PR DESCRIPTION
## Summary
- Add `operation_id`/`summary` to all API endpoints for readable MCP tool names
- Mount an MCP server at `/mcp` using `fastapi-mcp`'s Streamable HTTP transport (`mount_http()`)
- Expose only the full-detail event operations (plus `list_groups`) as MCP tools, since AI clients benefit from `description` always being present; the REST API itself is unchanged (`/events` and `/events/full` both still work as before)
- Pin `fastapi-mcp>=0.4.0` (earlier versions don't have `mount_http()`)

Scoped to the Docker/uvicorn deployment; the AWS Lambda (Mangum) target is not verified for this transport.

Closes #2

## Test plan
- [x] `pytest` (72 passed)
- [x] Verified `/mcp` via raw JSON-RPC (`initialize` → `tools/list` → `tools/call`) that only `list_events_full*` and `list_groups` are exposed
- [x] Verified `list_events_full` tool call result matches `GET /events/full` directly
- [x] Verified `/events` and `/events/full` REST endpoints still return 200 directly
- [ ] Verify with MCP Inspector (`npx @modelcontextprotocol/inspector`) against a running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)