### PR TITLE
Add GET /events/summary yearly aggregation endpoint

### DIFF
--- a/app/connpass.py
+++ b/app/connpass.py
@@ -14,7 +14,7 @@ class ConnpassException(Exception):
 class ConnpassEventRequest:
     def __init__(self, event_id=None, prefecture=None, subdomain=None,
                  ym=None, ymd=None, keyword=None, cache=None,
-                 api_key=None, user_agent=None):
+                 api_key=None, user_agent=None, cache_ttl=3600):
         self.url = "https://connpass.com/api/v2/events/"
         self.api_key = api_key
         self.event_id = event_id
@@ -31,6 +31,7 @@ class ConnpassEventRequest:
         self.cache = cache
         self.api_key = api_key
         self.user_agent = user_agent
+        self.cache_ttl = cache_ttl
         self.last_modified = datetime.fromtimestamp(0, timezone.utc)
 
     def get_event(self):
@@ -77,7 +78,8 @@ class ConnpassEventRequest:
                 json = response.json()
                 last_modified = datetime.now(timezone.utc)
                 if self.cache is not None:
-                    self.cache.set(params, json, last_modified=last_modified)
+                    self.cache.set(params, json, last_modified=last_modified,
+                                   ex=self.cache_ttl)
             events += self.__convert_to_events(json['events'])
 
             if last_modified is not None:

--- a/app/main.py
+++ b/app/main.py
@@ -293,7 +293,9 @@ async def read_events_summary(
     ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]
 
     events, last_modified = get_events({"ym": ym, "keyword": None},
-                                       background_tasks)
+                                       background_tasks,
+                                       ex=3600*24*7,  # 7 days
+                                       cache_ttl=3600*24)  # 24 hours
     groups, _ = get_groups({}, background_tasks)
     group_by_key = {g.key: g for g in groups}
 
@@ -363,7 +365,9 @@ mcp.mount_http()
 
 
 def get_events(params,
-               background_tasks: BackgroundTasks = None
+               background_tasks: BackgroundTasks = None,
+               ex: int = 3600*72,  # 72 hours
+               cache_ttl: int = None
                ) -> Tuple[List[EventDetail], datetime]:
     global cache
 
@@ -372,9 +376,9 @@ def get_events(params,
     events, last_modified = get_events_from_cache(cache, params)
 
     if events is None:
-        events, last_modified = request_events(params)
+        events, last_modified = request_events(params, cache_ttl=cache_ttl)
 
-    background_tasks.add_task(fetch_events, params)
+    background_tasks.add_task(fetch_events, params, ex, cache_ttl)
 
     return events, last_modified
 
@@ -390,29 +394,29 @@ def get_events_from_cache(cache, params) -> Tuple[List[EventDetail], datetime]:
     return None, None
 
 
-def fetch_events(params):
+def fetch_events(params, ex: int = 3600*72, cache_ttl: int = None):  # 72 hours
     global cache
 
     events = None
     last_modified = None
     try:
-        events, last_modified = request_events(params)
+        events, last_modified = request_events(params, cache_ttl=cache_ttl)
 
     except (ConnpassException, IcalException, ArchiveException):
         return
 
     if events is not None:
         json = EventDetail.to_json(events)
-        cache.set(params, json, last_modified=last_modified,
-                  ex=3600*72)  # 72 hours
+        cache.set(params, json, last_modified=last_modified, ex=ex)
 
 
-def request_events(params) -> Tuple[List[EventDetail], datetime]:
+def request_events(params, cache_ttl: int = None) -> Tuple[List[EventDetail], datetime]:
     global cache
 
     ym = params["ym"] if "ym" in params else None
     ymd = params["ymd"] if "ymd" in params else None
     keyword = params["keyword"] if "keyword" in params else None
+    connpass_cache_ttl = cache_ttl if cache_ttl is not None else 3600
 
     user_agent = get_user_agent(config)
 
@@ -424,7 +428,8 @@ def request_events(params) -> Tuple[List[EventDetail], datetime]:
             r = ConnpassEventRequest(prefecture=prefecture,
                                      ym=ym, ymd=ymd, cache=cache,
                                      api_key=connpass_api_key,
-                                     user_agent=user_agent
+                                     user_agent=user_agent,
+                                     cache_ttl=connpass_cache_ttl
                                      )
             events += r.get_events()
             last_modified = max(last_modified, r.get_last_modified())
@@ -434,7 +439,8 @@ def request_events(params) -> Tuple[List[EventDetail], datetime]:
             r = ConnpassEventRequest(subdomain=subdomain,
                                      ym=ym, ymd=ymd, cache=cache,
                                      api_key=connpass_api_key,
-                                     user_agent=user_agent
+                                     user_agent=user_agent,
+                                     cache_ttl=connpass_cache_ttl
                                      )
             events += r.get_events()
             last_modified = max(last_modified, r.get_last_modified())

--- a/app/main.py
+++ b/app/main.py
@@ -378,7 +378,8 @@ def get_events(params,
     if events is None:
         events, last_modified = request_events(params, cache_ttl=cache_ttl)
 
-    background_tasks.add_task(fetch_events, params, ex, cache_ttl)
+    if background_tasks is not None:
+        background_tasks.add_task(fetch_events, params, ex, cache_ttl)
 
     return events, last_modified
 

--- a/app/main.py
+++ b/app/main.py
@@ -298,7 +298,7 @@ async def read_events_summary(
     group_by_key = {g.key: g for g in groups}
 
     year_stats = {
-        y: {"event_count": 0, "group_counts": {}, "group_names": {}, "group_urls": {}}
+        y: {"event_count": 0, "group_counts": {}}
         for y in range(from_year, to_year + 1)
     }
     heatmap_counts = {
@@ -315,27 +315,25 @@ async def read_events_summary(
             continue
         stats = year_stats[year]
         stats["event_count"] += 1
-        if ev.group_key:
+        if ev.group_key and ev.group_key in group_by_key:
             stats["group_counts"][ev.group_key] = \
                 stats["group_counts"].get(ev.group_key, 0) + 1
-            stats["group_names"].setdefault(ev.group_key, ev.group_name)
-            stats["group_urls"].setdefault(ev.group_key, ev.group_url)
 
     years = []
     for year in range(from_year, to_year + 1):
         stats = year_stats[year]
-        group_activities = []
         sorted_keys = sorted(stats["group_counts"].items(),
                              key=lambda kv: kv[1], reverse=True)
-        for key, count in sorted_keys:
-            g = group_by_key.get(key)
-            group_activities.append(GroupActivity(
+        group_activities = [
+            GroupActivity(
                 key=key,
-                name=g.title if g else stats["group_names"].get(key),
-                image_url=g.image_url if g else None,
-                url=g.url if g else stats["group_urls"].get(key),
+                name=group_by_key[key].title,
+                image_url=group_by_key[key].image_url,
+                url=group_by_key[key].url,
                 event_count=count
-            ))
+            )
+            for key, count in sorted_keys
+        ]
         years.append(YearSummary(year=year, event_count=stats["event_count"],
                                  groups=group_activities))
 

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from .connpass import ConnpassEventRequest, ConnpassGroupRequest, ConnpassExcept
 from .icalendar import IcalEventRequest, IcalException
 from .archive import ArchiveIndexRequest, ArchiveException
 from .models import Event, EventDetail, Group
+from .models import GroupActivity, YearSummary, HeatmapBucket, EventsSummary
 from .cache import EventRequestCache
 from .keywords import KeywordExtractor
 import asyncio
@@ -277,6 +278,78 @@ async def read_groups(
         response.headers["Last-Modified"] = last_modified_str
         response.headers["Cache-Control"] = "public, max-age=3600"
     return groups
+
+
+@app.get("/events/summary", response_model=EventsSummary,
+         operation_id="summary_events_by_year",
+         summary="Get yearly event summary with group highlights and activity heatmap")
+async def read_events_summary(
+    response: Response,
+    background_tasks: BackgroundTasks
+):
+    from_year = 2010
+    to_year = datetime.now().year
+
+    ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]
+
+    events, last_modified = get_events({"ym": ym, "keyword": None},
+                                       background_tasks)
+    groups, _ = get_groups({}, background_tasks)
+    group_by_key = {g.key: g for g in groups}
+
+    year_stats = {
+        y: {"event_count": 0, "group_counts": {}, "group_names": {}, "group_urls": {}}
+        for y in range(from_year, to_year + 1)
+    }
+    heatmap_counts = {
+        f"{y:04}-{m:02}": 0
+        for y in range(from_year, to_year + 1) for m in range(1, 13)
+    }
+
+    for ev in events:
+        year = int(ev.started_at[:4])
+        period = ev.started_at[:7]
+        if period in heatmap_counts:
+            heatmap_counts[period] += 1
+        if year not in year_stats:
+            continue
+        stats = year_stats[year]
+        stats["event_count"] += 1
+        if ev.group_key:
+            stats["group_counts"][ev.group_key] = \
+                stats["group_counts"].get(ev.group_key, 0) + 1
+            stats["group_names"].setdefault(ev.group_key, ev.group_name)
+            stats["group_urls"].setdefault(ev.group_key, ev.group_url)
+
+    years = []
+    for year in range(from_year, to_year + 1):
+        stats = year_stats[year]
+        group_activities = []
+        sorted_keys = sorted(stats["group_counts"].items(),
+                             key=lambda kv: kv[1], reverse=True)
+        for key, count in sorted_keys:
+            g = group_by_key.get(key)
+            group_activities.append(GroupActivity(
+                key=key,
+                name=g.title if g else stats["group_names"].get(key),
+                image_url=g.image_url if g else None,
+                url=g.url if g else stats["group_urls"].get(key),
+                event_count=count
+            ))
+        years.append(YearSummary(year=year, event_count=stats["event_count"],
+                                 groups=group_activities))
+
+    heatmap = [HeatmapBucket(period=p, count=c)
+              for p, c in sorted(heatmap_counts.items())]
+
+    summary = EventsSummary(from_year=from_year, to_year=to_year,
+                            granularity="month", years=years, heatmap=heatmap)
+
+    if last_modified is not None:
+        last_modified_str = last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        response.headers["Last-Modified"] = last_modified_str
+        response.headers["Cache-Control"] = "public, max-age=3600"
+    return summary
 
 
 mcp = FastApiMCP(app, include_operations=[

--- a/app/main.py
+++ b/app/main.py
@@ -296,8 +296,12 @@ async def read_events_summary(
                                        background_tasks,
                                        ex=3600*24*7,  # 7 days
                                        cache_ttl=3600*24)  # 24 hours
-    groups, _ = get_groups({}, background_tasks)
+    groups, groups_last_modified = get_groups({}, background_tasks)
     group_by_key = {g.key: g for g in groups}
+
+    if groups_last_modified is not None:
+        last_modified = (groups_last_modified if last_modified is None
+                         else max(last_modified, groups_last_modified))
 
     year_stats = {
         y: {"event_count": 0, "group_counts": {}}

--- a/app/models.py
+++ b/app/models.py
@@ -236,3 +236,34 @@ class Group:
             }
 
         raise ValueError("data must be Group or List[Group]")
+
+
+@dataclass
+class GroupActivity:
+    key: str
+    name: Optional[str]
+    image_url: Optional[str]
+    url: Optional[str]
+    event_count: int
+
+
+@dataclass
+class YearSummary:
+    year: int
+    event_count: int
+    groups: List[GroupActivity]
+
+
+@dataclass
+class HeatmapBucket:
+    period: str
+    count: int
+
+
+@dataclass
+class EventsSummary:
+    from_year: int
+    to_year: int
+    granularity: str
+    years: List[YearSummary]
+    heatmap: List[HeatmapBucket]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -347,6 +347,45 @@ def test_read_events_full_fromto_year_month_invalid():
     assert response.status_code == 400
 
 
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+@patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.main.get_groups_from_icalendar")
+def test_read_events_summary(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/events/summary")
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "public, max-age=3600"
+    assert "Last-Modified" in response.headers
+
+    data = response.json()
+    assert data["from_year"] == 2010
+    assert data["granularity"] == "month"
+    assert len(data["years"]) == data["to_year"] - data["from_year"] + 1
+
+    # Archive mock event: 2012-05-19, group_key "yamanashi-web" (present in group directory)
+    year_2012 = next(y for y in data["years"] if y["year"] == 2012)
+    assert year_2012["event_count"] == 1
+    assert year_2012["groups"][0]["key"] == "yamanashi-web"
+    assert year_2012["groups"][0]["name"] == "山梨Web勉強会"
+    assert year_2012["groups"][0]["url"] == "https://example.com/yamanashi-web"
+
+    # Ical mock event: 2022-01-01, group_key "Group Key 1" (absent from group directory,
+    # falls back to the event's own group_name/group_url)
+    year_2022 = next(y for y in data["years"] if y["year"] == 2022)
+    fallback_group = next(g for g in year_2022["groups"] if g["key"] == "Group Key 1")
+    assert fallback_group["name"] == "Group Name 1"
+    assert fallback_group["url"] == "Group URL 1"
+
+    # Connpass mock events have an empty group_key and must not appear as a group
+    assert all(g["key"] != "" for y in data["years"] for g in y["groups"])
+
+    heatmap_by_period = {h["period"]: h["count"] for h in data["heatmap"]}
+    assert heatmap_by_period["2012-05"] == 1
+    assert heatmap_by_period["2010-01"] == 0
+
+
 @patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
 @patch("app.main.get_groups_from_icalendar")
 def test_read_group(mock_get_groups_from_icalendar):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -371,12 +371,11 @@ def test_read_events_summary(mock_get_groups_from_icalendar):
     assert year_2012["groups"][0]["name"] == "山梨Web勉強会"
     assert year_2012["groups"][0]["url"] == "https://example.com/yamanashi-web"
 
-    # Ical mock event: 2022-01-01, group_key "Group Key 1" (absent from group directory,
-    # falls back to the event's own group_name/group_url)
+    # Ical mock event: 2022-01-01, group_key "Group Key 1" is absent from the
+    # group directory (/groups), so it must not appear even though the event exists
     year_2022 = next(y for y in data["years"] if y["year"] == 2022)
-    fallback_group = next(g for g in year_2022["groups"] if g["key"] == "Group Key 1")
-    assert fallback_group["name"] == "Group Name 1"
-    assert fallback_group["url"] == "Group URL 1"
+    assert year_2022["event_count"] == 2
+    assert all(g["key"] != "Group Key 1" for g in year_2022["groups"])
 
     # Connpass mock events have an empty group_key and must not appear as a group
     assert all(g["key"] != "" for y in data["years"] for g in y["groups"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ import pytest
 from app.main import app, get_user_agent, get_groups_from_icalendar
 from app.main import request_events, request_groups, get_groups_from_archives
 from app.main import get_archive_urls, preload_archive_indexes
+from app.main import get_events
 from app.cache import EventRequestCache
 from app.archive import ArchiveException
 from app.models import EventDetail, Group
@@ -520,6 +521,16 @@ def test_get_groups_from_icalendar():
     assert groups[1].image_url is None
     assert groups[1].ical_url == "http://example.com/ical"
     assert groups[1].description is None
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+@patch("app.main.cache", EventRequestCache(prefix="test_get_events_no_bg_"))
+def test_get_events_without_background_tasks():
+    events, last_modified = get_events({"ym": ["202201"], "keyword": None})
+
+    assert isinstance(events, list)
+    assert len(events) > 0
 
 
 @patch("app.main.ArchiveIndexRequest", MockArchiveIndexRequest)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -385,6 +385,52 @@ def test_read_events_summary(mock_get_groups_from_icalendar):
     assert heatmap_by_period["2010-01"] == 0
 
 
+class MockConnpassEventRequestCapturingTTL:
+    received_cache_ttl = []
+
+    def __init__(self, **kwargs):
+        MockConnpassEventRequestCapturingTTL.received_cache_ttl.append(
+            kwargs.get("cache_ttl"))
+
+    def get_events(self):
+        return []
+
+    def get_last_modified(self):
+        return datetime.fromtimestamp(123, timezone.utc)
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequestCapturingTTL)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+@patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.main.get_groups_from_icalendar")
+@patch("app.main.cache", EventRequestCache(prefix="test_summary_ttl_"))
+def test_read_events_summary_uses_extended_ttls(mock_get_groups_from_icalendar):
+    import app.main as main_module
+
+    mock_get_groups_from_icalendar.return_value = []
+    MockConnpassEventRequestCapturingTTL.received_cache_ttl = []
+
+    response = client.get("/events/summary")
+    assert response.status_code == 200
+
+    # The low-level connpass cache_ttl (24h) must reach every
+    # ConnpassEventRequest call triggered by the summary endpoint.
+    assert len(MockConnpassEventRequestCapturingTTL.received_cache_ttl) > 0
+    assert all(ttl == 3600 * 24
+              for ttl in MockConnpassEventRequestCapturingTTL.received_cache_ttl)
+
+    # The high-level aggregated response must be cached for 7 days,
+    # not the default 72 hours used by the other /events endpoints.
+    from_year = 2010
+    to_year = datetime.now().year
+    ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]
+    params = {"ym": ym, "keyword": None}
+    key = main_module.cache.generate_key(params) + ":content"
+    expiry = main_module.cache._expiry[key]
+    remaining = expiry - datetime.now(timezone.utc).timestamp()
+    assert 3600 * 24 * 6 < remaining <= 3600 * 24 * 7
+
+
 @patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
 @patch("app.main.get_groups_from_icalendar")
 def test_read_group(mock_get_groups_from_icalendar):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -386,6 +386,28 @@ def test_read_events_summary(mock_get_groups_from_icalendar):
     assert heatmap_by_period["2010-01"] == 0
 
 
+class MockConnpassGroupRequestNewerLastModified(MockConnpassGroupRequest):
+    def get_last_modified(self):
+        return datetime.fromtimestamp(999999, timezone.utc)
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+@patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequestNewerLastModified)
+@patch("app.main.get_groups_from_icalendar")
+@patch("app.main.cache", EventRequestCache(prefix="test_summary_last_modified_"))
+def test_read_events_summary_last_modified_reflects_newer_groups(
+        mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/events/summary")
+    assert response.status_code == 200
+
+    expected = datetime.fromtimestamp(999999, timezone.utc) \
+        .strftime("%a, %d %b %Y %H:%M:%S GMT")
+    assert response.headers["Last-Modified"] == expected
+
+
 class MockConnpassEventRequestCapturingTTL:
     received_cache_ttl = []
 
@@ -420,8 +442,10 @@ def test_read_events_summary_uses_extended_ttls(mock_get_groups_from_icalendar):
     assert all(ttl == 3600 * 24
               for ttl in MockConnpassEventRequestCapturingTTL.received_cache_ttl)
 
-    # The high-level aggregated response must be cached for 7 days,
-    # not the default 72 hours used by the other /events endpoints.
+    # The cached raw EventDetail list (get_events()'s EventRequestCache
+    # entry) must use a 7 day expiry, not the default 72 hours used by
+    # the other /events endpoints. The years/heatmap payload built from
+    # it is not itself cached and is recomputed on every request.
     from_year = 2010
     to_year = datetime.now().year
     ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]


### PR DESCRIPTION
## Summary
- Add `GET /events/summary`, returning 2010–present in one response: per-year event/group counts and a zero-filled monthly activity heatmap, for the frontend's planned year-index page (year cards, community highlights, cross-year heatmap).
- Fetches the whole range with a single `get_events()` call (one connpass API call plus pagination) instead of one call per year, reusing the existing cache-backed `get_events()`/`get_groups()` helpers.
- `years[].groups` only includes groups that also appear in `/groups` (no ad-hoc fallback to per-event group name/url).
- Extends caching for the underlying event data this endpoint fetches: the raw `EventDetail` list returned by `get_events()` is cached 7 days (vs. 72h default), and the underlying connpass raw responses are cached 24h (vs. 1h default) — since 2010–present data churns far less than the recent-events endpoints. Threaded as optional `ex`/`cache_ttl` params through `get_events()`/`fetch_events()`/`request_events()`/`ConnpassEventRequest`, defaulting to prior behavior everywhere else. The per-year/heatmap aggregation itself is still recomputed on every request from that cached event list (cheap — a single pass over a few hundred events), it is not cached as a precomputed response. icalendar's raw-content cache is keyed by URL only (shared across endpoints), so it's left untouched to avoid unreliable TTL overwrites.
- `get_events()` now guards against a `None` background_tasks (previously would raise `AttributeError` if ever called without one, though no call site currently does).

## Test plan
- [x] `python3 -m pytest tests/test_main.py -q` — 29 passed
- [x] Manually verified against a local dev server hitting real connpass/archive data: 17 years, 204 zero-filled monthly buckets, correct `Cache-Control`/`Last-Modified` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
