### PR TITLE
Add this-week/next-week event endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -232,6 +232,9 @@ def get_max_age_until_next_period(days: int, max_age: int = 3600) -> int:
     describes, otherwise a response cached just before midnight (or a week
     boundary) could still be served as "today"/"this week" after it rolls
     over."""
+    if days not in (1, 7):
+        raise ValueError(f"Unsupported days for cache boundary clamping: {days}")
+
     now = datetime.now()
     today = now.date()
     period_start = today - timedelta(days=today.weekday()) if days == 7 else today

--- a/app/main.py
+++ b/app/main.py
@@ -92,6 +92,20 @@ async def read_events_today(
                                                now.day, keyword)
 
 
+@app.get("/events/week/this", response_model=List[Event],
+         operation_id="list_events_this_week",
+         summary="List this week's events")
+async def read_events_this_week(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    keyword: str = None
+):
+    today = datetime.now().date()
+    monday = today - timedelta(days=today.weekday())
+    return await read_events_for_days(response, background_tasks,
+                                      monday, 7, keyword)
+
+
 @app.get("/events/in/{year}", response_model=List[Event],
          operation_id="list_events_by_year",
          summary="List events in a specific year")
@@ -172,6 +186,24 @@ async def read_events_fromto_year_month(
             m = 1
 
     events, last_modified = get_events({"ym": ym, "keyword": keyword},
+                                       background_tasks)
+
+    if last_modified is not None:
+        last_modified_str = last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        response.headers["Last-Modified"] = last_modified_str
+        response.headers["Cache-Control"] = "public, max-age=3600"
+    return events
+
+
+async def read_events_for_days(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    base_date,
+    days: int,
+    keyword: str = None
+):
+    ymd = [(base_date + timedelta(days=i)).strftime("%Y%m%d") for i in range(days)]
+    events, last_modified = get_events({"ymd": ymd, "keyword": keyword},
                                        background_tasks)
 
     if last_modified is not None:

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,7 @@ from .keywords import KeywordExtractor
 import asyncio
 import os
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, time as time_of_day
 import yaml
 from dotenv import load_dotenv
 from mangum import Mangum
@@ -86,10 +86,9 @@ async def read_events_today(
     background_tasks: BackgroundTasks,
     keyword: str = None
 ):
-    now = datetime.now()
-    return await read_events_in_year_month_day(response, background_tasks,
-                                               now.year, now.month,
-                                               now.day, keyword)
+    today = datetime.now().date()
+    return await read_events_for_days(response, background_tasks,
+                                      today, 1, keyword)
 
 
 @app.get("/events/week/this", response_model=List[Event],
@@ -223,8 +222,22 @@ async def read_events_for_days(
     if last_modified is not None:
         last_modified_str = last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT")
         response.headers["Last-Modified"] = last_modified_str
-        response.headers["Cache-Control"] = "public, max-age=3600"
+        max_age = get_max_age_until_next_period(days)
+        response.headers["Cache-Control"] = f"public, max-age={max_age}"
     return events
+
+
+def get_max_age_until_next_period(days: int, max_age: int = 3600) -> int:
+    """Clamp max_age so an HTTP cache can't outlive the day/week the response
+    describes, otherwise a response cached just before midnight (or a week
+    boundary) could still be served as "today"/"this week" after it rolls
+    over."""
+    now = datetime.now()
+    today = now.date()
+    period_start = today - timedelta(days=today.weekday()) if days == 7 else today
+    boundary = datetime.combine(period_start + timedelta(days=days), time_of_day.min)
+    seconds_until_boundary = int((boundary - now).total_seconds())
+    return max(0, min(max_age, seconds_until_boundary))
 
 
 @app.get("/events/full", response_model=List[EventDetail],

--- a/app/main.py
+++ b/app/main.py
@@ -260,6 +260,17 @@ async def read_events_full_this_week(
     return await read_events_this_week(response, background_tasks, keyword)
 
 
+@app.get("/events/full/week/next", response_model=List[EventDetail],
+         operation_id="list_events_full_next_week",
+         summary="List next week's events with full details")
+async def read_events_full_next_week(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    keyword: str = None
+):
+    return await read_events_next_week(response, background_tasks, keyword)
+
+
 @app.get("/events/full/in/{year}", response_model=List[EventDetail],
          operation_id="list_events_full_by_year",
          summary="List events in a specific year with full details")
@@ -417,6 +428,7 @@ mcp = FastApiMCP(app, include_operations=[
     "list_events_full",
     "list_events_full_today",
     "list_events_full_this_week",
+    "list_events_full_next_week",
     "list_events_full_by_year",
     "list_events_full_by_month",
     "list_events_full_by_day",

--- a/app/main.py
+++ b/app/main.py
@@ -235,6 +235,17 @@ async def read_events_full_today(
     return await read_events_today(response, background_tasks, keyword)
 
 
+@app.get("/events/full/week/this", response_model=List[EventDetail],
+         operation_id="list_events_full_this_week",
+         summary="List this week's events with full details")
+async def read_events_full_this_week(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    keyword: str = None
+):
+    return await read_events_this_week(response, background_tasks, keyword)
+
+
 @app.get("/events/full/in/{year}", response_model=List[EventDetail],
          operation_id="list_events_full_by_year",
          summary="List events in a specific year with full details")
@@ -391,6 +402,7 @@ async def read_events_summary(
 mcp = FastApiMCP(app, include_operations=[
     "list_events_full",
     "list_events_full_today",
+    "list_events_full_this_week",
     "list_events_full_by_year",
     "list_events_full_by_month",
     "list_events_full_by_day",

--- a/app/main.py
+++ b/app/main.py
@@ -106,6 +106,20 @@ async def read_events_this_week(
                                       monday, 7, keyword)
 
 
+@app.get("/events/week/next", response_model=List[Event],
+         operation_id="list_events_next_week",
+         summary="List next week's events")
+async def read_events_next_week(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    keyword: str = None
+):
+    today = datetime.now().date()
+    next_monday = today - timedelta(days=today.weekday()) + timedelta(days=7)
+    return await read_events_for_days(response, background_tasks,
+                                      next_monday, 7, keyword)
+
+
 @app.get("/events/in/{year}", response_model=List[Event],
          operation_id="list_events_by_year",
          summary="List events in a specific year")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -260,6 +260,14 @@ def test_read_events_this_week():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_next_week():
+    response = client.get("/events/week/next")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
 def test_read_events_in_year():
     response = client.get("/events/in/2023")
     assert response.status_code == 200

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ import pytest
 from app.main import app, get_user_agent, get_groups_from_icalendar
 from app.main import request_events, request_groups, get_groups_from_archives
 from app.main import get_archive_urls, preload_archive_indexes
-from app.main import get_events
+from app.main import get_events, get_max_age_until_next_period
 from app.cache import EventRequestCache
 from app.archive import ArchiveException
 from app.models import EventDetail, Group
@@ -528,6 +528,36 @@ def test_read_group_includes_archive_source(mock_get_groups_from_icalendar):
     assert archive_group["archive_source"] == "yamanashi-event-archive"
     assert archive_group["archive_url"] == \
         "https://github.com/yuukis/yamanashi-event-archive"
+
+
+class FixedDatetimeNearBoundary(datetime):
+    # Sunday 23:30, 30 minutes before both the daily and weekly rollover
+    fixed_now = datetime(2026, 7, 12, 23, 30, 0)
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls.fixed_now
+
+
+class FixedDatetimeMidWeek(datetime):
+    # Wednesday 10:00, far from any daily or weekly rollover
+    fixed_now = datetime(2026, 7, 8, 10, 0, 0)
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls.fixed_now
+
+
+def test_get_max_age_until_next_period_clamped_near_boundary():
+    with patch("app.main.datetime", FixedDatetimeNearBoundary):
+        assert get_max_age_until_next_period(1) == 1800
+        assert get_max_age_until_next_period(7) == 1800
+
+
+def test_get_max_age_until_next_period_uses_default_far_from_boundary():
+    with patch("app.main.datetime", FixedDatetimeMidWeek):
+        assert get_max_age_until_next_period(1) == 3600
+        assert get_max_age_until_next_period(7) == 3600
 
 
 def test_get_user_agent():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -252,6 +252,14 @@ def test_read_events_today():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_this_week():
+    response = client.get("/events/week/this")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
 def test_read_events_in_year():
     response = client.get("/events/in/2023")
     assert response.status_code == 200

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ from app.main import get_events, get_max_age_until_next_period
 from app.cache import EventRequestCache
 from app.archive import ArchiveException
 from app.models import EventDetail, Group
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 client = TestClient(app)
 
@@ -250,20 +250,56 @@ def test_read_events_today():
     assert isinstance(response.json(), list)
 
 
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+class MockConnpassEventRequestCapturingYmd:
+    received_ymd = []
+
+    def __init__(self, **kwargs):
+        MockConnpassEventRequestCapturingYmd.received_ymd.append(kwargs.get("ymd"))
+
+    def get_events(self):
+        return []
+
+    def get_last_modified(self):
+        return datetime.fromtimestamp(123, timezone.utc)
+
+
+def _assert_consecutive_week_starting_monday(ymd, expected_monday):
+    dates = [datetime.strptime(d, "%Y%m%d").date() for d in ymd]
+    assert dates == [expected_monday + timedelta(days=i) for i in range(7)]
+    assert dates[0].weekday() == 0
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequestCapturingYmd)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
 def test_read_events_this_week():
+    MockConnpassEventRequestCapturingYmd.received_ymd = []
+
     response = client.get("/events/week/this")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
+    today = datetime.now().date()
+    this_monday = today - timedelta(days=today.weekday())
+    assert len(MockConnpassEventRequestCapturingYmd.received_ymd) > 0
+    for ymd in MockConnpassEventRequestCapturingYmd.received_ymd:
+        _assert_consecutive_week_starting_monday(ymd, this_monday)
 
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequestCapturingYmd)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
 def test_read_events_next_week():
+    MockConnpassEventRequestCapturingYmd.received_ymd = []
+
     response = client.get("/events/week/next")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
+    today = datetime.now().date()
+    this_monday = today - timedelta(days=today.weekday())
+    next_monday = this_monday + timedelta(days=7)
+    assert len(MockConnpassEventRequestCapturingYmd.received_ymd) > 0
+    for ymd in MockConnpassEventRequestCapturingYmd.received_ymd:
+        _assert_consecutive_week_starting_monday(ymd, next_monday)
 
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
@@ -558,6 +594,11 @@ def test_get_max_age_until_next_period_uses_default_far_from_boundary():
     with patch("app.main.datetime", FixedDatetimeMidWeek):
         assert get_max_age_until_next_period(1) == 3600
         assert get_max_age_until_next_period(7) == 3600
+
+
+def test_get_max_age_until_next_period_rejects_unsupported_days():
+    with pytest.raises(ValueError):
+        get_max_age_until_next_period(3)
 
 
 def test_get_user_agent():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -315,6 +315,15 @@ def test_read_events_full_today():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_full_this_week():
+    response = client.get("/events/full/week/this")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+    assert "description" in response.json()[0]
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
 def test_read_events_full_in_year():
     response = client.get("/events/full/in/2023")
     assert response.status_code == 200

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -332,6 +332,15 @@ def test_read_events_full_this_week():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_full_next_week():
+    response = client.get("/events/full/week/next")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+    assert "description" in response.json()[0]
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
 def test_read_events_full_in_year():
     response = client.get("/events/full/in/2023")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Add `/events/week/this` and `/events/week/next` (plus `/events/full/...` variants) via a new internal `read_events_for_days(base_date, days)` helper that fetches N days of events starting from a given base date. "This week" and "next week" are Monday-Sunday calendar weeks.
- Both full-detail variants are exposed through the MCP tool set alongside the existing `today` tools.
- Fix a cache staleness issue affecting `/events/today`, `/events/week/this`, and `/events/week/next`: since these URLs are fixed but their content depends on "now" at request time, a flat `Cache-Control: max-age=3600` could let a response cached just before a day/week boundary keep being served as stale after it rolls over. `max-age` is now clamped to the time remaining until the next relevant boundary (day or week), capped at 3600s.

## Test plan
- [x] `python3 -m pytest -q` — 82 passed
- [x] Manual review of new/changed endpoints against existing `today`/`full` conventions