### PR TITLE
Consolidate /events/full/* into /events/* with a fields= selector

### DIFF
--- a/app/archive.py
+++ b/app/archive.py
@@ -1,6 +1,6 @@
 import requests
 from datetime import datetime, timezone
-from .models import EventDetail, Group
+from .models import Event, Group
 
 ARCHIVE_REQUEST_TIMEOUT = 10
 
@@ -27,7 +27,7 @@ class ArchiveIndexRequest:
                 last_modified = datetime.now(timezone.utc)
                 self.__set_json_to_cache(json, last_modified)
 
-            events = EventDetail.from_json(json.get("events", []))
+            events = Event.from_json(json.get("events", []))
             return self.__find_by_ym_ymd(events)
 
         except requests.RequestException as e:

--- a/app/connpass.py
+++ b/app/connpass.py
@@ -2,7 +2,7 @@ import requests
 import re
 import time
 from datetime import datetime, timezone
-from .models import EventDetail, Group
+from .models import Event, Group
 
 
 class ConnpassException(Exception):
@@ -154,7 +154,7 @@ class ConnpassEventRequest:
                 group_url = item["group"]["url"]
 
             events.append(
-                EventDetail(
+                Event(
                     uid=uid,
                     event_id=event_id,
                     title=item["title"],

--- a/app/icalendar.py
+++ b/app/icalendar.py
@@ -1,7 +1,7 @@
 import requests
 import re
 from icalendar import Calendar as IcalCalendar
-from .models import EventDetail
+from .models import Event
 from datetime import datetime, timezone
 
 
@@ -102,7 +102,7 @@ class IcalEventRequest:
             dtend = data.get("dtend").dt
             open_status = self.__make_open_status(dtstart, dtend)
 
-            event = EventDetail.from_json({
+            event = Event.from_json({
                 "uid": data.get("uid"),
                 "title": data.get("summary"),
                 "event_url": data.get("url"),

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple
 from fastapi import FastAPI, BackgroundTasks, Path, HTTPException
-from fastapi.responses import RedirectResponse, Response
+from fastapi.responses import RedirectResponse, Response, JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from .connpass import ConnpassEventRequest, ConnpassGroupRequest, ConnpassException
 from .icalendar import IcalEventRequest, IcalException
@@ -60,14 +60,15 @@ def docs_redirect():
     return RedirectResponse(url="/docs")
 
 
-@app.get("/events", response_model=List[Event],
+@app.get("/events", response_model=List[EventDetail],
          operation_id="list_events",
          summary="List recent events")
 async def read_events(
     response: Response,
     background_tasks: BackgroundTasks,
     keyword: str = None,
-    uid: str = None
+    uid: str = None,
+    fields: str = None
 ):
     days = config["recent_days"] if "recent_days" in config else 90
     now = datetime.now()
@@ -76,54 +77,57 @@ async def read_events(
     return await read_events_fromto_year_month(response, background_tasks,
                                                dt_from.year, dt_from.month,
                                                dt_to.year, dt_to.month,
-                                               keyword, uid)
+                                               keyword, uid, fields)
 
 
-@app.get("/events/today", response_model=List[Event],
+@app.get("/events/today", response_model=List[EventDetail],
          operation_id="list_events_today",
          summary="List today's events")
 async def read_events_today(
     response: Response,
     background_tasks: BackgroundTasks,
     keyword: str = None,
-    uid: str = None
+    uid: str = None,
+    fields: str = None
 ):
     today = datetime.now().date()
     return await read_events_for_days(response, background_tasks,
-                                      today, 1, keyword, uid)
+                                      today, 1, keyword, uid, fields)
 
 
-@app.get("/events/week/this", response_model=List[Event],
+@app.get("/events/week/this", response_model=List[EventDetail],
          operation_id="list_events_this_week",
          summary="List this week's events")
 async def read_events_this_week(
     response: Response,
     background_tasks: BackgroundTasks,
     keyword: str = None,
-    uid: str = None
+    uid: str = None,
+    fields: str = None
 ):
     today = datetime.now().date()
     monday = today - timedelta(days=today.weekday())
     return await read_events_for_days(response, background_tasks,
-                                      monday, 7, keyword, uid)
+                                      monday, 7, keyword, uid, fields)
 
 
-@app.get("/events/week/next", response_model=List[Event],
+@app.get("/events/week/next", response_model=List[EventDetail],
          operation_id="list_events_next_week",
          summary="List next week's events")
 async def read_events_next_week(
     response: Response,
     background_tasks: BackgroundTasks,
     keyword: str = None,
-    uid: str = None
+    uid: str = None,
+    fields: str = None
 ):
     today = datetime.now().date()
     next_monday = today - timedelta(days=today.weekday()) + timedelta(days=7)
     return await read_events_for_days(response, background_tasks,
-                                      next_monday, 7, keyword, uid)
+                                      next_monday, 7, keyword, uid, fields)
 
 
-@app.get("/events/in/{year}", response_model=List[Event],
+@app.get("/events/in/{year}", response_model=List[EventDetail],
          operation_id="list_events_by_year",
          summary="List events in a specific year")
 async def read_events_in_year(
@@ -131,14 +135,15 @@ async def read_events_in_year(
     background_tasks: BackgroundTasks,
     year: int = Path(ge=2010, le=2040),
     keyword: str = None,
-    uid: str = None
+    uid: str = None,
+    fields: str = None
 ):
     return await read_events_fromto_year_month(response, background_tasks,
                                                year, 1, year, 12,
-                                               keyword, uid)
+                                               keyword, uid, fields)
 
 
-@app.get("/events/in/{year}/{month}", response_model=List[Event],
+@app.get("/events/in/{year}/{month}", response_model=List[EventDetail],
          operation_id="list_events_by_month",
          summary="List events in a specific year and month")
 async def read_events_in_year_month(
@@ -147,14 +152,15 @@ async def read_events_in_year_month(
     year: int = Path(ge=2010, le=2040),
     month: int = Path(ge=1, le=12),
     keyword: str = None,
-    uid: str = None
+    uid: str = None,
+    fields: str = None
 ):
     return await read_events_fromto_year_month(response, background_tasks,
                                                year, month, year, month,
-                                               keyword, uid)
+                                               keyword, uid, fields)
 
 
-@app.get("/events/in/{year}/{month}/{day}", response_model=List[Event],
+@app.get("/events/in/{year}/{month}/{day}", response_model=List[EventDetail],
          operation_id="list_events_by_day",
          summary="List events on a specific day")
 async def read_events_in_year_month_day(
@@ -164,21 +170,19 @@ async def read_events_in_year_month_day(
     month: int = Path(ge=1, le=12),
     day: int = Path(ge=1, le=31),
     keyword: str = None,
-    uid: str = None
+    uid: str = None,
+    fields: str = None
 ):
     ymd = [f"{year:04}{month:02}{day:02}"]
     events, last_modified = get_events(
         {"ymd": ymd, "keyword": keyword, "uid": uid}, background_tasks)
 
-    if last_modified is not None:
-        last_modified_str = last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT")
-        response.headers["Last-Modified"] = last_modified_str
-        response.headers["Cache-Control"] = "public, max-age=3600"
-    return events
+    return build_events_response(response, events, last_modified,
+                                 "public, max-age=3600", fields)
 
 
 @app.get("/events/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
-         response_model=List[Event],
+         response_model=List[EventDetail],
          operation_id="list_events_by_range",
          summary="List events within a date range")
 async def read_events_fromto_year_month(
@@ -189,7 +193,8 @@ async def read_events_fromto_year_month(
     to_year: int = Path(ge=2010, le=2040),
     to_month: int = Path(ge=1, le=12),
     keyword: str = None,
-    uid: str = None
+    uid: str = None,
+    fields: str = None
 ):
     if from_year > to_year or (from_year == to_year and from_month > to_month):
         raise HTTPException(status_code=400, detail="Invalid date range")
@@ -209,11 +214,8 @@ async def read_events_fromto_year_month(
     events, last_modified = get_events(
         {"ym": ym, "keyword": keyword, "uid": uid}, background_tasks)
 
-    if last_modified is not None:
-        last_modified_str = last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT")
-        response.headers["Last-Modified"] = last_modified_str
-        response.headers["Cache-Control"] = "public, max-age=3600"
-    return events
+    return build_events_response(response, events, last_modified,
+                                 "public, max-age=3600", fields)
 
 
 async def read_events_for_days(
@@ -222,18 +224,16 @@ async def read_events_for_days(
     base_date,
     days: int,
     keyword: str = None,
-    uid: str = None
+    uid: str = None,
+    fields: str = None
 ):
     ymd = [(base_date + timedelta(days=i)).strftime("%Y%m%d") for i in range(days)]
     events, last_modified = get_events(
         {"ymd": ymd, "keyword": keyword, "uid": uid}, background_tasks)
 
-    if last_modified is not None:
-        last_modified_str = last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT")
-        response.headers["Last-Modified"] = last_modified_str
-        max_age = get_max_age_until_next_period(days)
-        response.headers["Cache-Control"] = f"public, max-age={max_age}"
-    return events
+    max_age = get_max_age_until_next_period(days)
+    return build_events_response(response, events, last_modified,
+                                 f"public, max-age={max_age}", fields)
 
 
 def get_max_age_until_next_period(days: int, max_age: int = 3600) -> int:
@@ -252,118 +252,35 @@ def get_max_age_until_next_period(days: int, max_age: int = 3600) -> int:
     return max(0, min(max_age, seconds_until_boundary))
 
 
-@app.get("/events/full", response_model=List[EventDetail],
-         operation_id="list_events_full",
-         summary="List recent events with full details")
-async def read_events_full(
-    response: Response,
-    background_tasks: BackgroundTasks,
-    keyword: str = None,
-    uid: str = None
-):
-    return await read_events(response, background_tasks, keyword, uid)
+def filter_event_fields(events, fields: str = None):
+    """Return events pruned to the requested comma-separated field names,
+    or None if no filtering should be applied (fields is absent/empty)."""
+    if fields is None:
+        return None
+
+    field_names = [f.strip() for f in fields.split(",") if f.strip()]
+    if not field_names:
+        return None
+
+    return [{k: v for k, v in d.items() if k in field_names}
+            for d in EventDetail.to_json(events)]
 
 
-@app.get("/events/full/today", response_model=List[EventDetail],
-         operation_id="list_events_full_today",
-         summary="List today's events with full details")
-async def read_events_full_today(
-    response: Response,
-    background_tasks: BackgroundTasks,
-    keyword: str = None,
-    uid: str = None
-):
-    return await read_events_today(response, background_tasks, keyword, uid)
+def build_events_response(response: Response, events, last_modified,
+                          cache_control: str, fields: str = None):
+    headers = {}
+    if last_modified is not None:
+        headers["Last-Modified"] = last_modified.strftime(
+            "%a, %d %b %Y %H:%M:%S GMT")
+        headers["Cache-Control"] = cache_control
 
+    filtered = filter_event_fields(events, fields)
+    if filtered is None:
+        for key, value in headers.items():
+            response.headers[key] = value
+        return events
 
-@app.get("/events/full/week/this", response_model=List[EventDetail],
-         operation_id="list_events_full_this_week",
-         summary="List this week's events with full details")
-async def read_events_full_this_week(
-    response: Response,
-    background_tasks: BackgroundTasks,
-    keyword: str = None,
-    uid: str = None
-):
-    return await read_events_this_week(response, background_tasks, keyword, uid)
-
-
-@app.get("/events/full/week/next", response_model=List[EventDetail],
-         operation_id="list_events_full_next_week",
-         summary="List next week's events with full details")
-async def read_events_full_next_week(
-    response: Response,
-    background_tasks: BackgroundTasks,
-    keyword: str = None,
-    uid: str = None
-):
-    return await read_events_next_week(response, background_tasks, keyword, uid)
-
-
-@app.get("/events/full/in/{year}", response_model=List[EventDetail],
-         operation_id="list_events_full_by_year",
-         summary="List events in a specific year with full details")
-async def read_events_full_in_year(
-    response: Response,
-    background_tasks: BackgroundTasks,
-    year: int = Path(ge=2010, le=2040),
-    keyword: str = None,
-    uid: str = None
-):
-    return await read_events_in_year(response, background_tasks, year,
-                                     keyword, uid)
-
-
-@app.get("/events/full/in/{year}/{month}", response_model=List[EventDetail],
-         operation_id="list_events_full_by_month",
-         summary="List events in a specific year and month with full details")
-async def read_events_full_in_year_month(
-    response: Response,
-    background_tasks: BackgroundTasks,
-    year: int = Path(ge=2010, le=2040),
-    month: int = Path(ge=1, le=12),
-    keyword: str = None,
-    uid: str = None
-):
-    return await read_events_in_year_month(response, background_tasks,
-                                           year, month, keyword, uid)
-
-
-@app.get("/events/full/in/{year}/{month}/{day}",
-         response_model=List[EventDetail],
-         operation_id="list_events_full_by_day",
-         summary="List events on a specific day with full details")
-async def read_events_full_in_year_month_day(
-    response: Response,
-    background_tasks: BackgroundTasks,
-    year: int = Path(ge=2010, le=2040),
-    month: int = Path(ge=1, le=12),
-    day: int = Path(ge=1, le=31),
-    keyword: str = None,
-    uid: str = None
-):
-    return await read_events_in_year_month_day(response, background_tasks,
-                                               year, month, day, keyword, uid)
-
-
-@app.get("/events/full/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
-         response_model=List[EventDetail],
-         operation_id="list_events_full_by_range",
-         summary="List events within a date range with full details")
-async def read_events_full_fromto_year_month(
-    response: Response,
-    background_tasks: BackgroundTasks,
-    from_year: int = Path(ge=2010, le=2040),
-    from_month: int = Path(ge=1, le=12),
-    to_year: int = Path(ge=2010, le=2040),
-    to_month: int = Path(ge=1, le=12),
-    keyword: str = None,
-    uid: str = None
-):
-    return await read_events_fromto_year_month(response, background_tasks,
-                                               from_year, from_month,
-                                               to_year, to_month,
-                                               keyword, uid)
+    return JSONResponse(content=filtered, headers=headers)
 
 
 @app.get("/groups", response_model=List[Group],
@@ -459,14 +376,14 @@ async def read_events_summary(
 
 
 mcp = FastApiMCP(app, include_operations=[
-    "list_events_full",
-    "list_events_full_today",
-    "list_events_full_this_week",
-    "list_events_full_next_week",
-    "list_events_full_by_year",
-    "list_events_full_by_month",
-    "list_events_full_by_day",
-    "list_events_full_by_range",
+    "list_events",
+    "list_events_today",
+    "list_events_this_week",
+    "list_events_next_week",
+    "list_events_by_year",
+    "list_events_by_month",
+    "list_events_by_day",
+    "list_events_by_range",
     "list_groups",
 ])
 mcp.mount_http()

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from .connpass import ConnpassEventRequest, ConnpassGroupRequest, ConnpassException
 from .icalendar import IcalEventRequest, IcalException
 from .archive import ArchiveIndexRequest, ArchiveException
-from .models import Event, EventDetail, Group
+from .models import Event, Group
 from .models import GroupActivity, YearSummary, HeatmapBucket, EventsSummary
 from .cache import EventRequestCache
 from .keywords import KeywordExtractor
@@ -60,7 +60,7 @@ def docs_redirect():
     return RedirectResponse(url="/docs")
 
 
-@app.get("/events", response_model=List[EventDetail],
+@app.get("/events", response_model=List[Event],
          operation_id="list_events",
          summary="List recent events")
 async def read_events(
@@ -80,7 +80,7 @@ async def read_events(
                                                keyword, uid, fields)
 
 
-@app.get("/events/today", response_model=List[EventDetail],
+@app.get("/events/today", response_model=List[Event],
          operation_id="list_events_today",
          summary="List today's events")
 async def read_events_today(
@@ -95,7 +95,7 @@ async def read_events_today(
                                       today, 1, keyword, uid, fields)
 
 
-@app.get("/events/week/this", response_model=List[EventDetail],
+@app.get("/events/week/this", response_model=List[Event],
          operation_id="list_events_this_week",
          summary="List this week's events")
 async def read_events_this_week(
@@ -111,7 +111,7 @@ async def read_events_this_week(
                                       monday, 7, keyword, uid, fields)
 
 
-@app.get("/events/week/next", response_model=List[EventDetail],
+@app.get("/events/week/next", response_model=List[Event],
          operation_id="list_events_next_week",
          summary="List next week's events")
 async def read_events_next_week(
@@ -127,7 +127,7 @@ async def read_events_next_week(
                                       next_monday, 7, keyword, uid, fields)
 
 
-@app.get("/events/in/{year}", response_model=List[EventDetail],
+@app.get("/events/in/{year}", response_model=List[Event],
          operation_id="list_events_by_year",
          summary="List events in a specific year")
 async def read_events_in_year(
@@ -143,7 +143,7 @@ async def read_events_in_year(
                                                keyword, uid, fields)
 
 
-@app.get("/events/in/{year}/{month}", response_model=List[EventDetail],
+@app.get("/events/in/{year}/{month}", response_model=List[Event],
          operation_id="list_events_by_month",
          summary="List events in a specific year and month")
 async def read_events_in_year_month(
@@ -160,7 +160,7 @@ async def read_events_in_year_month(
                                                keyword, uid, fields)
 
 
-@app.get("/events/in/{year}/{month}/{day}", response_model=List[EventDetail],
+@app.get("/events/in/{year}/{month}/{day}", response_model=List[Event],
          operation_id="list_events_by_day",
          summary="List events on a specific day")
 async def read_events_in_year_month_day(
@@ -182,7 +182,7 @@ async def read_events_in_year_month_day(
 
 
 @app.get("/events/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
-         response_model=List[EventDetail],
+         response_model=List[Event],
          operation_id="list_events_by_range",
          summary="List events within a date range")
 async def read_events_fromto_year_month(
@@ -263,7 +263,7 @@ def filter_event_fields(events, fields: str = None):
         return None
 
     return [{k: v for k, v in d.items() if k in field_names}
-            for d in EventDetail.to_json(events)]
+            for d in Event.to_json(events)]
 
 
 def build_events_response(response: Response, events, last_modified,
@@ -403,7 +403,7 @@ def get_events(params,
                background_tasks: BackgroundTasks = None,
                ex: int = 3600*72,  # 72 hours
                cache_ttl: int = None
-               ) -> Tuple[List[EventDetail], datetime]:
+               ) -> Tuple[List[Event], datetime]:
     global cache
 
     last_modified = None
@@ -421,14 +421,14 @@ def get_events(params,
     return events, last_modified
 
 
-def get_events_from_cache(cache, params) -> Tuple[List[EventDetail], datetime]:
+def get_events_from_cache(cache, params) -> Tuple[List[Event], datetime]:
     response = cache.get(params)
     if response is None:
         return None, None
     json = response["json"]
     last_modified = response["last_modified"]
     if json is not None:
-        return EventDetail.from_json(json), last_modified
+        return Event.from_json(json), last_modified
     return None, None
 
 
@@ -444,11 +444,11 @@ def fetch_events(params, ex: int = 3600*72, cache_ttl: int = None):  # 72 hours
         return
 
     if events is not None:
-        json = EventDetail.to_json(events)
+        json = Event.to_json(events)
         cache.set(params, json, last_modified=last_modified, ex=ex)
 
 
-def request_events(params, cache_ttl: int = None) -> Tuple[List[EventDetail], datetime]:
+def request_events(params, cache_ttl: int = None) -> Tuple[List[Event], datetime]:
     global cache
 
     ym = params["ym"] if "ym" in params else None

--- a/app/main.py
+++ b/app/main.py
@@ -258,7 +258,7 @@ def filter_event_fields(events, fields: str = None):
     if fields is None:
         return None
 
-    field_names = [f.strip() for f in fields.split(",") if f.strip()]
+    field_names = {f.strip() for f in fields.split(",") if f.strip()}
     if not field_names:
         return None
 
@@ -280,6 +280,9 @@ def build_events_response(response: Response, events, last_modified,
             response.headers[key] = value
         return events
 
+    # Returning a JSONResponse here deliberately bypasses response_model
+    # validation/serialization, since the shape is a client-chosen subset
+    # of Event's fields rather than the full declared schema.
     return JSONResponse(content=filtered, headers=headers)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 from fastapi import FastAPI, BackgroundTasks, Path, HTTPException
 from fastapi.responses import RedirectResponse, Response, JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
@@ -424,7 +424,9 @@ def get_events(params,
     return events, last_modified
 
 
-def get_events_from_cache(cache, params) -> Tuple[List[Event], datetime]:
+def get_events_from_cache(
+    cache, params
+) -> Tuple[Optional[List[Event]], Optional[datetime]]:
     response = cache.get(params)
     if response is None:
         return None, None
@@ -552,7 +554,9 @@ def get_groups(params,
     return groups, last_modified
 
 
-def get_groups_from_cache(cache, params) -> Tuple[List[Group], datetime]:
+def get_groups_from_cache(
+    cache, params
+) -> Tuple[Optional[List[Group]], Optional[datetime]]:
     response = cache.get(params)
     if response is None:
         return None, None

--- a/app/models.py
+++ b/app/models.py
@@ -14,31 +14,6 @@ class Event:
     ended_at: str
     updated_at: str
     open_status: str
-    owner_name: Optional[str]
-    place: Optional[str]
-    address: Optional[str]
-    group_key: Optional[str]
-    group_name: Optional[str]
-    group_url: Optional[str]
-    keywords: Optional[List[str]] = None
-
-    @staticmethod
-    def distinct_by_uid(data):
-        return list({event.uid: event for event in data}.values())
-
-
-@dataclass
-class EventDetail(Event):
-    uid: str
-    event_id: Optional[int]
-    title: str
-    catch: Optional[str]
-    hash_tag: Optional[str]
-    event_url: str
-    started_at: str
-    ended_at: str
-    updated_at: str
-    open_status: str
     limit: Optional[int] = None
     accepted: Optional[int] = None
     waiting: Optional[int] = None
@@ -51,6 +26,11 @@ class EventDetail(Event):
     description: Optional[str] = None
     lat: Optional[str] = None
     lon: Optional[str] = None
+    keywords: Optional[List[str]] = None
+
+    @staticmethod
+    def distinct_by_uid(data):
+        return list({event.uid: event for event in data}.values())
 
     def contains_keyword(self, keyword: str):
         if keyword is None:
@@ -76,7 +56,7 @@ class EventDetail(Event):
                 return False
 
         return True
-    
+
     def is_valid(self):
         return all([
             self.uid,
@@ -91,10 +71,10 @@ class EventDetail(Event):
     @staticmethod
     def from_json(data: any):
         if isinstance(data, list):
-            return [EventDetail.from_json(item) for item in data]
+            return [Event.from_json(item) for item in data]
 
         if isinstance(data, dict):
-            return EventDetail(
+            return Event(
                 uid=data["uid"],
                 event_id=data.get("event_id"),
                 title=data["title"],
@@ -117,10 +97,10 @@ class EventDetail(Event):
                 description=data.get("description"),
                 lat=data.get("lat"),
                 lon=data.get("lon"),
-                keywords=EventDetail.sanitize_keywords(data.get("keywords"))
+                keywords=Event.sanitize_keywords(data.get("keywords"))
             )
 
-        raise ValueError("data must be EventDetail or List[EventDetail]")
+        raise ValueError("data must be Event or List[Event]")
 
     @staticmethod
     def sanitize_keywords(data: any) -> Optional[List[str]]:
@@ -135,9 +115,9 @@ class EventDetail(Event):
     @staticmethod
     def to_json(data: any):
         if isinstance(data, list):
-            return [EventDetail.to_json(item) for item in data]
+            return [Event.to_json(item) for item in data]
 
-        if isinstance(data, EventDetail):
+        if isinstance(data, Event):
             return {
                 "uid": data.uid,
                 "event_id": data.event_id,
@@ -164,7 +144,7 @@ class EventDetail(Event):
                 "keywords": data.keywords
             }
 
-        raise ValueError("data must be EventDetail or List[EventDetail]")
+        raise ValueError("data must be Event or List[Event]")
 
 
 @dataclass

--- a/app/models.py
+++ b/app/models.py
@@ -100,7 +100,7 @@ class Event:
                 keywords=Event.sanitize_keywords(data.get("keywords"))
             )
 
-        raise ValueError("data must be Event or List[Event]")
+        raise ValueError("data must be dict or List[dict]")
 
     @staticmethod
     def sanitize_keywords(data: any) -> Optional[List[str]]:

--- a/docs/archive-index.md
+++ b/docs/archive-index.md
@@ -32,7 +32,7 @@ scope:
 
 ## JSON Format
 
-The top-level `events` array is converted to `EventDetail`. The top-level
+The top-level `events` array is converted to `Event`. The top-level
 `communities` array is converted to `Group`. The API adds `archive_source` and
 `archive_url` to each archive community from `source.name` and `source.url`.
 

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,11 +1,11 @@
 import unittest
 from app.keywords import KeywordExtractor
-from app.models import EventDetail
+from app.models import Event
 
 
 def make_event(title="", catch=None, hash_tag=None, description=None,
                group_key=None, group_name=None, keywords=None):
-    return EventDetail(
+    return Event(
         uid="event_1@example.com",
         event_id=1, title=title, catch=catch, hash_tag=hash_tag,
         event_url="https://example.com/event/1",
@@ -106,7 +106,7 @@ class TestKeywordExtractor(unittest.TestCase):
         self.assertNotIn("生成AI", keywords)
 
 
-class TestEventDetailKeywords(unittest.TestCase):
+class TestEventKeywords(unittest.TestCase):
     def test_from_json_inherits_keywords(self):
         data = {
             "uid": "event_1@example.com",
@@ -119,7 +119,7 @@ class TestEventDetailKeywords(unittest.TestCase):
             "keywords": ["Python", "初心者歓迎"]
         }
 
-        event = EventDetail.from_json(data)
+        event = Event.from_json(data)
 
         self.assertEqual(event.keywords, ["Python", "初心者歓迎"])
 
@@ -134,7 +134,7 @@ class TestEventDetailKeywords(unittest.TestCase):
             "open_status": "close"
         }
 
-        event = EventDetail.from_json(data)
+        event = Event.from_json(data)
 
         self.assertIsNone(event.keywords)
 
@@ -150,7 +150,7 @@ class TestEventDetailKeywords(unittest.TestCase):
             "keywords": [123, "Python", None]
         }
 
-        event = EventDetail.from_json(data)
+        event = Event.from_json(data)
 
         self.assertEqual(event.keywords, ["Python"])
 
@@ -167,13 +167,13 @@ class TestEventDetailKeywords(unittest.TestCase):
 
         # non-list and empty keywords fall back to extraction (None)
         for keywords in ["Python", 123, {}, [], [123, None]]:
-            event = EventDetail.from_json({**base, "keywords": keywords})
+            event = Event.from_json({**base, "keywords": keywords})
             self.assertIsNone(event.keywords)
 
     def test_to_json_contains_keywords(self):
         event = make_event(title="Event 1", keywords=["Python"])
 
-        data = EventDetail.to_json(event)
+        data = Event.to_json(event)
 
         self.assertEqual(data["keywords"], ["Python"])
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ from app.main import get_events, get_max_age_until_next_period
 from app.main import normalize_event_params
 from app.cache import EventRequestCache
 from app.archive import ArchiveException
-from app.models import EventDetail, Group
+from app.models import Event, Group
 from datetime import datetime, timedelta, timezone
 
 client = TestClient(app)
@@ -69,7 +69,7 @@ class MockConnpassEventRequest:
                 "lon": ""
             }
         ]
-        events = EventDetail.from_json(json)
+        events = Event.from_json(json)
         return events
 
     def get_last_modified(self):
@@ -137,7 +137,7 @@ class MockICalEventRequest:
                 "lon": None
             }
         ]
-        events = EventDetail.from_json(json)
+        events = Event.from_json(json)
         return events
 
     def get_last_modified(self):
@@ -180,7 +180,7 @@ class MockArchiveIndexRequest:
                 "lon": None
             }
         ]
-        return EventDetail.from_json(json)
+        return Event.from_json(json)
 
     def get_groups(self):
         json = [
@@ -582,7 +582,7 @@ def test_read_events_summary_uses_extended_ttls(mock_get_groups_from_icalendar):
     assert all(ttl == 3600 * 24
               for ttl in MockConnpassEventRequestCapturingTTL.received_cache_ttl)
 
-    # The cached raw EventDetail list (get_events()'s EventRequestCache
+    # The cached raw Event list (get_events()'s EventRequestCache
     # entry) must use a 7 day expiry, not the default 72 hours used by
     # the other /events endpoints. The years/heatmap payload built from
     # it is not itself cached and is recomputed on every request.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -232,7 +232,10 @@ def mock_archive_index_request():
 def test_read_events():
     response = client.get("/events")
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
+    events = response.json()
+    assert isinstance(events, list)
+    # /events now returns full details by default (no more /events/full split)
+    assert "description" in events[0]
 
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
@@ -248,7 +251,9 @@ def test_read_events_with_keyword():
 def test_read_events_today():
     response = client.get("/events/today")
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
 
 
 class MockConnpassEventRequestCapturingYmd:
@@ -277,7 +282,9 @@ def test_read_events_this_week():
 
     response = client.get("/events/week/this")
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
 
     today = datetime.now().date()
     this_monday = today - timedelta(days=today.weekday())
@@ -293,7 +300,9 @@ def test_read_events_next_week():
 
     response = client.get("/events/week/next")
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
 
     today = datetime.now().date()
     this_monday = today - timedelta(days=today.weekday())
@@ -308,7 +317,9 @@ def test_read_events_next_week():
 def test_read_events_in_year():
     response = client.get("/events/in/2023")
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
 
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
@@ -316,82 +327,9 @@ def test_read_events_in_year():
 def test_read_events_in_year_month():
     response = client.get("/events/in/2023/12")
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
-
-
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month_day():
-    response = client.get("/events/in/2024/01/28")
-    assert response.status_code == 200
-    assert isinstance(response.json(), list)
-
-
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_fromto_year_month():
-    response = client.get("/events/from/2023/12/to/2024/01")
-    assert response.status_code == 200
-    assert isinstance(response.json(), list)
-
-
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_fromto_year_month_invalid():
-    response = client.get("/events/from/2023/12/to/2022/11")
-    assert response.status_code == 400
-
-
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full():
-    response = client.get("/events/full")
-    assert response.status_code == 200
-    assert isinstance(response.json(), list)
-
-
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_today():
-    response = client.get("/events/full/today")
-    assert response.status_code == 200
-    assert isinstance(response.json(), list)
-
-
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_this_week():
-    response = client.get("/events/full/week/this")
-    assert response.status_code == 200
-    assert isinstance(response.json(), list)
-    assert "description" in response.json()[0]
-
-
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_next_week():
-    response = client.get("/events/full/week/next")
-    assert response.status_code == 200
-    assert isinstance(response.json(), list)
-    assert "description" in response.json()[0]
-
-
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_in_year():
-    response = client.get("/events/full/in/2023")
-    assert response.status_code == 200
-    assert isinstance(response.json(), list)
-    assert "description" in response.json()[0]
-
-
-@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_in_year_month():
-    response = client.get("/events/full/in/2023/12")
-    assert response.status_code == 200
-    assert isinstance(response.json(), list)
-    assert "description" in response.json()[0]
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
 
 
 def test_normalize_event_params_shares_cache_key_across_equivalent_uid():
@@ -413,8 +351,8 @@ def test_normalize_event_params_shares_cache_key_across_equivalent_uid():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_in_year_month_with_uid():
-    response = client.get("/events/full/in/2023/12",
+def test_read_events_in_year_month_with_uid():
+    response = client.get("/events/in/2023/12",
                           params={"uid": "UID 2"})
     assert response.status_code == 200
     events = response.json()
@@ -425,8 +363,8 @@ def test_read_events_full_in_year_month_with_uid():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_in_year_month_with_padded_uid():
-    response = client.get("/events/full/in/2023/12",
+def test_read_events_in_year_month_with_padded_uid():
+    response = client.get("/events/in/2023/12",
                           params={"uid": "  UID 2  "})
     assert response.status_code == 200
     events = response.json()
@@ -436,8 +374,8 @@ def test_read_events_full_in_year_month_with_padded_uid():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_in_year_month_with_unmatched_uid():
-    response = client.get("/events/full/in/2023/12",
+def test_read_events_in_year_month_with_unmatched_uid():
+    response = client.get("/events/in/2023/12",
                           params={"uid": "No Such UID"})
     assert response.status_code == 200
     assert response.json() == []
@@ -446,14 +384,14 @@ def test_read_events_full_in_year_month_with_unmatched_uid():
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
 @patch("app.main.cache", EventRequestCache(prefix="test_uid_noop_"))
-def test_read_events_full_in_year_month_with_empty_uid_is_noop():
+def test_read_events_in_year_month_with_empty_uid_is_noop():
     # Uses an isolated cache so this comparison isn't polluted by other
     # tests' cache entries for the same year/month. Compares uids rather
     # than full response bodies since uid="" now normalizes to the same
     # cache key as no uid at all, and a cache hit vs. a fresh computation
     # can otherwise disagree on unrelated fields (e.g. keywords).
-    baseline = client.get("/events/full/in/2023/12")
-    response = client.get("/events/full/in/2023/12",
+    baseline = client.get("/events/in/2023/12")
+    response = client.get("/events/in/2023/12",
                           params={"uid": ""})
     assert response.status_code == 200
     baseline_uids = sorted(ev["uid"] for ev in baseline.json())
@@ -464,16 +402,16 @@ def test_read_events_full_in_year_month_with_empty_uid_is_noop():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_in_year_month_with_uid_and_keyword():
+def test_read_events_in_year_month_with_uid_and_keyword():
     # "UID 1" is overwritten by the iCal source's non-matching event during
     # dedup, so combining it with a keyword that only the connpass version
     # would match must yield no results (AND semantics).
-    response = client.get("/events/full/in/2023/12",
+    response = client.get("/events/in/2023/12",
                           params={"uid": "UID 1", "keyword": "python"})
     assert response.status_code == 200
     assert response.json() == []
 
-    response = client.get("/events/full/in/2023/12",
+    response = client.get("/events/in/2023/12",
                           params={"uid": "UID 2", "keyword": "python"})
     assert response.status_code == 200
     events = response.json()
@@ -483,26 +421,70 @@ def test_read_events_full_in_year_month_with_uid_and_keyword():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_in_year_month_day():
-    response = client.get("/events/full/in/2024/01/28")
+def test_read_events_in_year_month_with_fields():
+    response = client.get("/events/in/2023/12",
+                          params={"uid": "UID 2", "fields": "uid,description"})
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
-    assert "description" in response.json()[0]
+    events = response.json()
+    assert len(events) == 1
+    assert events[0] == {"uid": "UID 2", "description": "Description"}
 
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_fromto_year_month():
-    response = client.get("/events/full/from/2023/12/to/2024/01")
+def test_read_events_in_year_month_with_fields_ignores_unknown_names():
+    response = client.get("/events/in/2023/12",
+                          params={"uid": "UID 2", "fields": "uid,bogus"})
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
-    assert "description" in response.json()[0]
+    events = response.json()
+    assert len(events) == 1
+    assert events[0] == {"uid": "UID 2"}
 
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_full_fromto_year_month_invalid():
-    response = client.get("/events/full/from/2023/12/to/2022/11")
+def test_read_events_in_year_month_with_empty_fields_is_noop():
+    baseline = client.get("/events/in/2023/12", params={"uid": "UID 2"})
+    response = client.get("/events/in/2023/12",
+                          params={"uid": "UID 2", "fields": ""})
+    assert response.status_code == 200
+    assert response.json() == baseline.json()
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_in_year_month_with_fields_keeps_cache_headers():
+    response = client.get("/events/in/2023/12",
+                          params={"uid": "UID 2", "fields": "uid"})
+    assert response.status_code == 200
+    assert "Last-Modified" in response.headers
+    assert response.headers["Cache-Control"] == "public, max-age=3600"
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_in_year_month_day():
+    response = client.get("/events/in/2024/01/28")
+    assert response.status_code == 200
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_fromto_year_month():
+    response = client.get("/events/from/2023/12/to/2024/01")
+    assert response.status_code == 200
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_fromto_year_month_invalid():
+    response = client.get("/events/from/2023/12/to/2022/11")
     assert response.status_code == 400
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 import unittest
-from app.models import Event, EventDetail, Group
+from app.models import Event, Group
 
 
 class TestEvent(unittest.TestCase):
@@ -44,7 +44,7 @@ class TestEvent(unittest.TestCase):
 
     def test_contains_keyword(self):
         # Create an event object
-        event = EventDetail(uid="event_1@example.com",
+        event = Event(uid="event_1@example.com",
                             event_id=1, title="Event 1", catch="Catch 1",
                             hash_tag="", event_url="",
                             started_at="", ended_at="", updated_at="",
@@ -110,7 +110,7 @@ class TestEvent(unittest.TestCase):
         }
 
         # Call the from_json method
-        event = EventDetail.from_json(data)
+        event = Event.from_json(data)
 
         # Check if the event object is created
         self.assertIsNotNone(event)
@@ -140,7 +140,7 @@ class TestEvent(unittest.TestCase):
     def test_to_json_with_list(self):
         # Create a list of event objects
         events = [
-            EventDetail(uid="event_1@example.com",
+            Event(uid="event_1@example.com",
                         event_id=1, title="Event 1", catch="Catch 1",
                         hash_tag="Hash Tag", event_url="Event URL",
                         started_at="2022-01-01T00:00:00+09:00",
@@ -152,7 +152,7 @@ class TestEvent(unittest.TestCase):
                         group_name="Group Name", group_url="Group URL",
                         description="Description",
                         lat="35.6895", lon="139.6917"),
-            EventDetail(uid="event_2@example.com",
+            Event(uid="event_2@example.com",
                         event_id=2, title="Event 2", catch="Catch 2",
                         hash_tag="Hash Tag", event_url="Event URL",
                         started_at="2022-01-01T00:00:00+09:00",
@@ -167,7 +167,7 @@ class TestEvent(unittest.TestCase):
         ]
 
         # Call the to_json method
-        data = EventDetail.to_json(events)
+        data = Event.to_json(events)
 
         # Check if the data object is created
         self.assertIsNotNone(data)
@@ -176,7 +176,7 @@ class TestEvent(unittest.TestCase):
         self.assertEqual(data[1]["event_id"], 2)
 
     def test_is_valid(self):
-        event1 = EventDetail(uid="event_1@example.com",
+        event1 = Event(uid="event_1@example.com",
                              event_id=1, title="Event 1", catch="Catch 1",
                              hash_tag="Hash Tag", event_url="Event URL",
                              started_at="2022-01-01T00:00:00+09:00",
@@ -188,7 +188,7 @@ class TestEvent(unittest.TestCase):
                              group_name="Group Name", group_url="Group URL",
                              description="Description",
                              lat=None, lon=None)
-        event2 = EventDetail(uid="event_2@example.com",
+        event2 = Event(uid="event_2@example.com",
                              event_id=1, title="Event 2", catch="Catch 2",
                              hash_tag="Hash Tag", event_url=None,
                              started_at="2022-01-01T00:00:00+09:00",


### PR DESCRIPTION
## Summary
- Removes the `/events/full/*` route family entirely. `/events/*` now always computes and can return full event data (description, limit, accepted, waiting, lat, lon), which it already fetched internally but previously hid behind a slimmer response_model.
- Adds an optional `fields=` query parameter (comma-separated field names) to prune the response to just what the client asks for, e.g. `?fields=uid,description`. Unknown field names are silently ignored. An absent or empty `fields` value returns the full object, unchanged from today.
- `fields` is applied only when building the HTTP response, after `get_events()`/caching — it never touches the cache key, so different `fields=` values for the same date/keyword/uid share the same underlying cached data.
- MCP tool surface is halved accordingly: `include_operations` now lists the (now full-featured) plain operation ids instead of the removed `*_full_*` ones.
- Follow-up simplification: merges the now-redundant `Event`/`EventDetail` dataclasses into a single `Event` class. Nothing constructed a plain `Event` or used the slim response_model anymore, so the split had become dead weight — `EventDetail` even had to redeclare every one of `Event`'s fields just to satisfy dataclass default-ordering rules.

**This is a breaking change**, agreed on explicitly:
- `/events/full`, `/events/full/today`, `/events/full/week/this`, `/events/full/week/next`, `/events/full/in/{year}`, `/events/full/in/{year}/{month}`, `/events/full/in/{year}/{month}/{day}`, and `/events/full/from/.../to/...` no longer exist.
- `/events/*` responses now include fields that used to be `/events/full/*`-only, growing the default payload size for existing consumers that don't pass `fields=`.
- The OpenAPI schema name changes from `EventDetail`/`Event` (two schemas) to a single `Event` schema.

## Test plan
- [x] `pytest` — 84 passed, stable across 5 repeated runs
- [x] Manually verified against live connpass data:
  - `GET /events` returns full fields by default
  - `GET /events?fields=uid,title,description` returns only those keys
  - `GET /events?fields=uid,bogus` silently ignores the unknown `bogus` field
  - `Last-Modified`/`Cache-Control` headers are present even when `fields=` triggers the manual JSON response path
- [x] Confirmed `/events/full/*` paths are gone from the generated OpenAPI schema and only the plain `/events/*` paths remain, backed by a single `Event` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)