### PR TITLE
Extend fields= filtering to /groups

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -177,8 +177,8 @@ async def read_events_in_year_month_day(
     events, last_modified = get_events(
         {"ymd": ymd, "keyword": keyword, "uid": uid}, background_tasks)
 
-    return build_events_response(response, events, last_modified,
-                                 "public, max-age=3600", fields)
+    return build_list_response(response, events, Event, last_modified,
+                               "public, max-age=3600", fields)
 
 
 @app.get("/events/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
@@ -214,8 +214,8 @@ async def read_events_fromto_year_month(
     events, last_modified = get_events(
         {"ym": ym, "keyword": keyword, "uid": uid}, background_tasks)
 
-    return build_events_response(response, events, last_modified,
-                                 "public, max-age=3600", fields)
+    return build_list_response(response, events, Event, last_modified,
+                               "public, max-age=3600", fields)
 
 
 async def read_events_for_days(
@@ -232,8 +232,8 @@ async def read_events_for_days(
         {"ymd": ymd, "keyword": keyword, "uid": uid}, background_tasks)
 
     max_age = get_max_age_until_next_period(days)
-    return build_events_response(response, events, last_modified,
-                                 f"public, max-age={max_age}", fields)
+    return build_list_response(response, events, Event, last_modified,
+                               f"public, max-age={max_age}", fields)
 
 
 def get_max_age_until_next_period(days: int, max_age: int = 3600) -> int:
@@ -252,9 +252,10 @@ def get_max_age_until_next_period(days: int, max_age: int = 3600) -> int:
     return max(0, min(max_age, seconds_until_boundary))
 
 
-def filter_event_fields(events, fields: str = None):
-    """Return events pruned to the requested comma-separated field names,
-    or None if no filtering should be applied (fields is absent/empty)."""
+def filter_model_fields(items, model, fields: str = None):
+    """Return items pruned to the requested comma-separated field names,
+    or None if no filtering should be applied (fields is absent/empty).
+    model must provide a to_json() static method, e.g. Event or Group."""
     if fields is None:
         return None
 
@@ -263,26 +264,26 @@ def filter_event_fields(events, fields: str = None):
         return None
 
     return [{k: v for k, v in d.items() if k in field_names}
-            for d in Event.to_json(events)]
+            for d in model.to_json(items)]
 
 
-def build_events_response(response: Response, events, last_modified,
-                          cache_control: str, fields: str = None):
+def build_list_response(response: Response, items, model, last_modified,
+                        cache_control: str, fields: str = None):
     headers = {}
     if last_modified is not None:
         headers["Last-Modified"] = last_modified.strftime(
             "%a, %d %b %Y %H:%M:%S GMT")
         headers["Cache-Control"] = cache_control
 
-    filtered = filter_event_fields(events, fields)
+    filtered = filter_model_fields(items, model, fields)
     if filtered is None:
         for key, value in headers.items():
             response.headers[key] = value
-        return events
+        return items
 
     # Returning a JSONResponse here deliberately bypasses response_model
     # validation/serialization, since the shape is a client-chosen subset
-    # of Event's fields rather than the full declared schema.
+    # of the model's fields rather than the full declared schema.
     return JSONResponse(content=filtered, headers=headers)
 
 
@@ -291,15 +292,13 @@ def build_events_response(response: Response, events, last_modified,
          summary="List community groups")
 async def read_groups(
     response: Response,
-    background_tasks: BackgroundTasks
+    background_tasks: BackgroundTasks,
+    fields: str = None
 ):
     groups, last_modified = get_groups({}, background_tasks)
 
-    if last_modified is not None:
-        last_modified_str = last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT")
-        response.headers["Last-Modified"] = last_modified_str
-        response.headers["Cache-Control"] = "public, max-age=3600"
-    return groups
+    return build_list_response(response, groups, Group, last_modified,
+                               "public, max-age=3600", fields)
 
 
 @app.get("/events/summary", response_model=EventsSummary,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -608,6 +608,41 @@ def test_read_group(mock_get_groups_from_icalendar):
 
 @patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
 @patch("app.main.get_groups_from_icalendar")
+def test_read_group_with_fields(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/groups", params={"fields": "key,title"})
+    assert response.status_code == 200
+    groups = response.json()
+    assert len(groups) > 0
+    assert groups[0] == {"key": "Key", "title": "Title"}
+
+
+@patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.main.get_groups_from_icalendar")
+def test_read_group_with_fields_ignores_unknown_names(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/groups", params={"fields": "key,bogus"})
+    assert response.status_code == 200
+    groups = response.json()
+    assert len(groups) > 0
+    assert groups[0] == {"key": "Key"}
+
+
+@patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.main.get_groups_from_icalendar")
+def test_read_group_with_empty_fields_is_noop(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    baseline = client.get("/groups")
+    response = client.get("/groups", params={"fields": ""})
+    assert response.status_code == 200
+    assert response.json() == baseline.json()
+
+
+@patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.main.get_groups_from_icalendar")
 @patch("app.main.config", {
     "metadata": {"version": "1.0.0"},
     "scope": {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -643,6 +643,17 @@ def test_read_group_with_empty_fields_is_noop(mock_get_groups_from_icalendar):
 
 @patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
 @patch("app.main.get_groups_from_icalendar")
+def test_read_group_with_fields_keeps_cache_headers(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/groups", params={"fields": "key"})
+    assert response.status_code == 200
+    assert "Last-Modified" in response.headers
+    assert response.headers["Cache-Control"] == "public, max-age=3600"
+
+
+@patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.main.get_groups_from_icalendar")
 @patch("app.main.config", {
     "metadata": {"version": "1.0.0"},
     "scope": {


### PR DESCRIPTION
## Summary
- Generalizes `filter_event_fields`/`build_events_response` (added in #9) into `filter_model_fields`/`build_list_response`, parameterized by a model class (`Event` or `Group`) instead of being hardcoded to `Event`.
- Adds the same `fields=` comma-separated selector to `/groups` that `/events/*` already has, e.g. `GET /groups?fields=key,title`. Same semantics: unknown field names are silently ignored, an absent/empty `fields` value returns the full object.

## Test plan
- [x] `pytest` — 87 passed, stable across repeated runs
- [x] Manually verified against live data:
  - `GET /groups` still returns full fields by default
  - `GET /groups?fields=key,title` returns only those two keys
  - `Last-Modified`/`Cache-Control` headers are present on the filtered response

🤖 Generated with [Claude Code](https://claude.com/claude-code)