### PR TITLE
Optimize event API paths, keep old paths deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,19 @@ If you have Docker and Docker Compose installed, you can use the following steps
 * Get today's events
 
     ```sh
-    curl http://localhost:8000/events/today
+    curl http://localhost:8000/events/day/today
     ```
 
 * Get events by year/month
 
     ```sh
-    curl http://localhost:8000/events/in/2023/12
+    curl http://localhost:8000/events/month/2023/12
     ```
 
 * Get events by date range
 
     ```sh
-    curl http://localhost:8000/events/from/2023/12/to/2024/02
+    curl http://localhost:8000/events/range/from/2023/12/to/2024/02
     ```
 
 * Get events by keyword

--- a/app/main.py
+++ b/app/main.py
@@ -483,9 +483,6 @@ async def read_events_summary_legacy(
     return await read_events_summary(response, background_tasks)
 
 
-# NOTE: operation_ids listed here are the canonical (non-deprecated) ones.
-# The "_legacy" operation_ids on the deprecated /events/today, /events/in/*,
-# /events/from/*/to/*, and /events/summary routes must never be added here.
 mcp = FastApiMCP(app, include_operations=[
     "list_events",
     "list_events_today",

--- a/app/main.py
+++ b/app/main.py
@@ -181,7 +181,7 @@ async def read_events_in_year_month_day(
                                "public, max-age=3600", fields)
 
 
-@app.get("/events/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
+@app.get("/events/range/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
          response_model=List[Event],
          operation_id="list_events_by_range",
          summary="List events within a date range")
@@ -216,6 +216,30 @@ async def read_events_range(
 
     return build_list_response(response, events, Event, last_modified,
                                "public, max-age=3600", fields)
+
+
+@app.get("/events/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
+         response_model=List[Event],
+         operation_id="list_events_by_range_legacy",
+         summary="List events within a date range",
+         description="Deprecated. Use GET "
+                     "/events/range/from/{from_year}/{from_month}/to/{to_year}/{to_month} "
+                     "instead.",
+         deprecated=True)
+async def read_events_fromto_year_month_legacy(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    from_year: int = Path(ge=2010, le=2040),
+    from_month: int = Path(ge=1, le=12),
+    to_year: int = Path(ge=2010, le=2040),
+    to_month: int = Path(ge=1, le=12),
+    keyword: str = None,
+    uid: str = None,
+    fields: str = None
+):
+    return await read_events_range(response, background_tasks,
+                                   from_year, from_month, to_year, to_month,
+                                   keyword, uid, fields)
 
 
 async def read_events_for_days(

--- a/app/main.py
+++ b/app/main.py
@@ -160,10 +160,10 @@ async def read_events_in_year_legacy(
                                   keyword, uid, fields)
 
 
-@app.get("/events/in/{year}/{month}", response_model=List[Event],
+@app.get("/events/month/{year}/{month}", response_model=List[Event],
          operation_id="list_events_by_month",
          summary="List events in a specific year and month")
-async def read_events_in_year_month(
+async def read_events_month(
     response: Response,
     background_tasks: BackgroundTasks,
     year: int = Path(ge=2010, le=2040),
@@ -174,6 +174,24 @@ async def read_events_in_year_month(
 ):
     return await read_events_range(response, background_tasks,
                                    year, month, year, month,
+                                   keyword, uid, fields)
+
+
+@app.get("/events/in/{year}/{month}", response_model=List[Event],
+         operation_id="list_events_by_month_legacy",
+         summary="List events in a specific year and month",
+         description="Deprecated. Use GET /events/month/{year}/{month} instead.",
+         deprecated=True)
+async def read_events_in_year_month_legacy(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    year: int = Path(ge=2010, le=2040),
+    month: int = Path(ge=1, le=12),
+    keyword: str = None,
+    uid: str = None,
+    fields: str = None
+):
+    return await read_events_month(response, background_tasks, year, month,
                                    keyword, uid, fields)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -127,10 +127,10 @@ async def read_events_next_week(
                                       next_monday, 7, keyword, uid, fields)
 
 
-@app.get("/events/in/{year}", response_model=List[Event],
+@app.get("/events/year/{year}", response_model=List[Event],
          operation_id="list_events_by_year",
          summary="List events in a specific year")
-async def read_events_in_year(
+async def read_events_year(
     response: Response,
     background_tasks: BackgroundTasks,
     year: int = Path(ge=2010, le=2040),
@@ -141,6 +141,23 @@ async def read_events_in_year(
     return await read_events_range(response, background_tasks,
                                    year, 1, year, 12,
                                    keyword, uid, fields)
+
+
+@app.get("/events/in/{year}", response_model=List[Event],
+         operation_id="list_events_by_year_legacy",
+         summary="List events in a specific year",
+         description="Deprecated. Use GET /events/year/{year} instead.",
+         deprecated=True)
+async def read_events_in_year_legacy(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    year: int = Path(ge=2010, le=2040),
+    keyword: str = None,
+    uid: str = None,
+    fields: str = None
+):
+    return await read_events_year(response, background_tasks, year,
+                                  keyword, uid, fields)
 
 
 @app.get("/events/in/{year}/{month}", response_model=List[Event],

--- a/app/main.py
+++ b/app/main.py
@@ -195,10 +195,10 @@ async def read_events_in_year_month_legacy(
                                    keyword, uid, fields)
 
 
-@app.get("/events/in/{year}/{month}/{day}", response_model=List[Event],
+@app.get("/events/day/{year}/{month}/{day}", response_model=List[Event],
          operation_id="list_events_by_day",
          summary="List events on a specific day")
-async def read_events_in_year_month_day(
+async def read_events_day(
     response: Response,
     background_tasks: BackgroundTasks,
     year: int = Path(ge=2010, le=2040),
@@ -214,6 +214,25 @@ async def read_events_in_year_month_day(
 
     return build_list_response(response, events, Event, last_modified,
                                "public, max-age=3600", fields)
+
+
+@app.get("/events/in/{year}/{month}/{day}", response_model=List[Event],
+         operation_id="list_events_by_day_legacy",
+         summary="List events on a specific day",
+         description="Deprecated. Use GET /events/day/{year}/{month}/{day} instead.",
+         deprecated=True)
+async def read_events_in_year_month_day_legacy(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    year: int = Path(ge=2010, le=2040),
+    month: int = Path(ge=1, le=12),
+    day: int = Path(ge=1, le=31),
+    keyword: str = None,
+    uid: str = None,
+    fields: str = None
+):
+    return await read_events_day(response, background_tasks, year, month, day,
+                                 keyword, uid, fields)
 
 
 @app.get("/events/range/from/{from_year}/{from_month}/to/{to_year}/{to_month}",

--- a/app/main.py
+++ b/app/main.py
@@ -74,10 +74,10 @@ async def read_events(
     now = datetime.now()
     dt_from = now - timedelta(days=days)
     dt_to = now + timedelta(days=days)
-    return await read_events_fromto_year_month(response, background_tasks,
-                                               dt_from.year, dt_from.month,
-                                               dt_to.year, dt_to.month,
-                                               keyword, uid, fields)
+    return await read_events_range(response, background_tasks,
+                                   dt_from.year, dt_from.month,
+                                   dt_to.year, dt_to.month,
+                                   keyword, uid, fields)
 
 
 @app.get("/events/today", response_model=List[Event],
@@ -138,9 +138,9 @@ async def read_events_in_year(
     uid: str = None,
     fields: str = None
 ):
-    return await read_events_fromto_year_month(response, background_tasks,
-                                               year, 1, year, 12,
-                                               keyword, uid, fields)
+    return await read_events_range(response, background_tasks,
+                                   year, 1, year, 12,
+                                   keyword, uid, fields)
 
 
 @app.get("/events/in/{year}/{month}", response_model=List[Event],
@@ -155,9 +155,9 @@ async def read_events_in_year_month(
     uid: str = None,
     fields: str = None
 ):
-    return await read_events_fromto_year_month(response, background_tasks,
-                                               year, month, year, month,
-                                               keyword, uid, fields)
+    return await read_events_range(response, background_tasks,
+                                   year, month, year, month,
+                                   keyword, uid, fields)
 
 
 @app.get("/events/in/{year}/{month}/{day}", response_model=List[Event],
@@ -185,7 +185,7 @@ async def read_events_in_year_month_day(
          response_model=List[Event],
          operation_id="list_events_by_range",
          summary="List events within a date range")
-async def read_events_fromto_year_month(
+async def read_events_range(
     response: Response,
     background_tasks: BackgroundTasks,
     from_year: int = Path(ge=2010, le=2040),

--- a/app/main.py
+++ b/app/main.py
@@ -395,8 +395,8 @@ async def read_groups(
                                "public, max-age=3600", fields)
 
 
-@app.get("/events/summary", response_model=EventsSummary,
-         operation_id="summary_events_by_year",
+@app.get("/summary/events", response_model=EventsSummary,
+         operation_id="summary_events",
          summary="Get yearly event summary with group highlights and activity heatmap")
 async def read_events_summary(
     response: Response,
@@ -471,6 +471,21 @@ async def read_events_summary(
     return summary
 
 
+@app.get("/events/summary", response_model=EventsSummary,
+         operation_id="summary_events_legacy",
+         summary="Get yearly event summary with group highlights and activity heatmap",
+         description="Deprecated. Use GET /summary/events instead.",
+         deprecated=True)
+async def read_events_summary_legacy(
+    response: Response,
+    background_tasks: BackgroundTasks
+):
+    return await read_events_summary(response, background_tasks)
+
+
+# NOTE: operation_ids listed here are the canonical (non-deprecated) ones.
+# The "_legacy" operation_ids on the deprecated /events/today, /events/in/*,
+# /events/from/*/to/*, and /events/summary routes must never be added here.
 mcp = FastApiMCP(app, include_operations=[
     "list_events",
     "list_events_today",

--- a/app/main.py
+++ b/app/main.py
@@ -80,10 +80,10 @@ async def read_events(
                                    keyword, uid, fields)
 
 
-@app.get("/events/today", response_model=List[Event],
+@app.get("/events/day/today", response_model=List[Event],
          operation_id="list_events_today",
          summary="List today's events")
-async def read_events_today(
+async def read_events_day_today(
     response: Response,
     background_tasks: BackgroundTasks,
     keyword: str = None,
@@ -93,6 +93,22 @@ async def read_events_today(
     today = datetime.now().date()
     return await read_events_for_days(response, background_tasks,
                                       today, 1, keyword, uid, fields)
+
+
+@app.get("/events/today", response_model=List[Event],
+         operation_id="list_events_today_legacy",
+         summary="List today's events",
+         description="Deprecated. Use GET /events/day/today instead.",
+         deprecated=True)
+async def read_events_today_legacy(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    keyword: str = None,
+    uid: str = None,
+    fields: str = None
+):
+    return await read_events_day_today(response, background_tasks,
+                                       keyword, uid, fields)
 
 
 @app.get("/events/week/this", response_model=List[Event],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1005,3 +1005,49 @@ def test_preload_archive_indexes_does_not_raise_on_error():
     with patch("app.main.ArchiveIndexRequest",
                MockFailingPreloadArchiveIndexRequest):
         preload_archive_indexes()
+
+
+def test_legacy_routes_marked_deprecated_in_openapi_schema():
+    schema = client.get("/openapi.json").json()
+    legacy = [
+        "/events/today",
+        "/events/in/{year}",
+        "/events/in/{year}/{month}",
+        "/events/in/{year}/{month}/{day}",
+        "/events/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
+        "/events/summary",
+    ]
+    for path in legacy:
+        op = schema["paths"][path]["get"]
+        assert op["deprecated"] is True
+        assert op["operationId"].endswith("_legacy")
+
+    canonical = [
+        "/events", "/events/day/today", "/events/week/this", "/events/week/next",
+        "/events/year/{year}", "/events/month/{year}/{month}",
+        "/events/day/{year}/{month}/{day}",
+        "/events/range/from/{from_year}/{from_month}/to/{to_year}/{to_month}",
+        "/summary/events", "/groups",
+    ]
+    for path in canonical:
+        op = schema["paths"][path]["get"]
+        assert not op.get("deprecated", False)
+
+
+def test_mcp_excludes_legacy_operations():
+    from app.main import mcp
+
+    tool_names = {t.name for t in mcp.tools}
+    for legacy_id in [
+        "list_events_today_legacy", "list_events_by_year_legacy",
+        "list_events_by_month_legacy", "list_events_by_day_legacy",
+        "list_events_by_range_legacy", "summary_events_legacy",
+    ]:
+        assert legacy_id not in tool_names
+
+    for canonical_id in [
+        "list_events", "list_events_today", "list_events_this_week",
+        "list_events_next_week", "list_events_by_year", "list_events_by_month",
+        "list_events_by_day", "list_events_by_range", "list_groups",
+    ]:
+        assert canonical_id in tool_names

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -314,7 +314,17 @@ def test_read_events_next_week():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year():
+def test_read_events_year():
+    response = client.get("/events/year/2023")
+    assert response.status_code == 200
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_in_year_legacy_path_still_works():
     response = client.get("/events/in/2023")
     assert response.status_code == 200
     events = response.json()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -473,7 +473,24 @@ def test_read_events_in_year_month_day():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_fromto_year_month():
+def test_read_events_range():
+    response = client.get("/events/range/from/2023/12/to/2024/01")
+    assert response.status_code == 200
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_range_invalid():
+    response = client.get("/events/range/from/2023/12/to/2022/11")
+    assert response.status_code == 400
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_fromto_year_month_legacy_path_still_works():
     response = client.get("/events/from/2023/12/to/2024/01")
     assert response.status_code == 200
     events = response.json()
@@ -483,7 +500,7 @@ def test_read_events_fromto_year_month():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_fromto_year_month_invalid():
+def test_read_events_fromto_year_month_invalid_legacy_path_still_works():
     response = client.get("/events/from/2023/12/to/2022/11")
     assert response.status_code == 400
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -483,7 +483,17 @@ def test_read_events_month_with_fields_keeps_cache_headers():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month_day():
+def test_read_events_day():
+    response = client.get("/events/day/2024/01/28")
+    assert response.status_code == 200
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_in_year_month_day_legacy_path_still_works():
     response = client.get("/events/in/2024/01/28")
     assert response.status_code == 200
     events = response.json()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -334,7 +334,17 @@ def test_read_events_in_year_legacy_path_still_works():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month():
+def test_read_events_month():
+    response = client.get("/events/month/2023/12")
+    assert response.status_code == 200
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_in_year_month_legacy_path_still_works():
     response = client.get("/events/in/2023/12")
     assert response.status_code == 200
     events = response.json()
@@ -361,8 +371,8 @@ def test_normalize_event_params_shares_cache_key_across_equivalent_uid():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month_with_uid():
-    response = client.get("/events/in/2023/12",
+def test_read_events_month_with_uid():
+    response = client.get("/events/month/2023/12",
                           params={"uid": "UID 2"})
     assert response.status_code == 200
     events = response.json()
@@ -373,8 +383,8 @@ def test_read_events_in_year_month_with_uid():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month_with_padded_uid():
-    response = client.get("/events/in/2023/12",
+def test_read_events_month_with_padded_uid():
+    response = client.get("/events/month/2023/12",
                           params={"uid": "  UID 2  "})
     assert response.status_code == 200
     events = response.json()
@@ -384,8 +394,8 @@ def test_read_events_in_year_month_with_padded_uid():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month_with_unmatched_uid():
-    response = client.get("/events/in/2023/12",
+def test_read_events_month_with_unmatched_uid():
+    response = client.get("/events/month/2023/12",
                           params={"uid": "No Such UID"})
     assert response.status_code == 200
     assert response.json() == []
@@ -394,14 +404,14 @@ def test_read_events_in_year_month_with_unmatched_uid():
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
 @patch("app.main.cache", EventRequestCache(prefix="test_uid_noop_"))
-def test_read_events_in_year_month_with_empty_uid_is_noop():
+def test_read_events_month_with_empty_uid_is_noop():
     # Uses an isolated cache so this comparison isn't polluted by other
     # tests' cache entries for the same year/month. Compares uids rather
     # than full response bodies since uid="" now normalizes to the same
     # cache key as no uid at all, and a cache hit vs. a fresh computation
     # can otherwise disagree on unrelated fields (e.g. keywords).
-    baseline = client.get("/events/in/2023/12")
-    response = client.get("/events/in/2023/12",
+    baseline = client.get("/events/month/2023/12")
+    response = client.get("/events/month/2023/12",
                           params={"uid": ""})
     assert response.status_code == 200
     baseline_uids = sorted(ev["uid"] for ev in baseline.json())
@@ -412,16 +422,16 @@ def test_read_events_in_year_month_with_empty_uid_is_noop():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month_with_uid_and_keyword():
+def test_read_events_month_with_uid_and_keyword():
     # "UID 1" is overwritten by the iCal source's non-matching event during
     # dedup, so combining it with a keyword that only the connpass version
     # would match must yield no results (AND semantics).
-    response = client.get("/events/in/2023/12",
+    response = client.get("/events/month/2023/12",
                           params={"uid": "UID 1", "keyword": "python"})
     assert response.status_code == 200
     assert response.json() == []
 
-    response = client.get("/events/in/2023/12",
+    response = client.get("/events/month/2023/12",
                           params={"uid": "UID 2", "keyword": "python"})
     assert response.status_code == 200
     events = response.json()
@@ -431,8 +441,8 @@ def test_read_events_in_year_month_with_uid_and_keyword():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month_with_fields():
-    response = client.get("/events/in/2023/12",
+def test_read_events_month_with_fields():
+    response = client.get("/events/month/2023/12",
                           params={"uid": "UID 2", "fields": "uid,description"})
     assert response.status_code == 200
     events = response.json()
@@ -442,8 +452,8 @@ def test_read_events_in_year_month_with_fields():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month_with_fields_ignores_unknown_names():
-    response = client.get("/events/in/2023/12",
+def test_read_events_month_with_fields_ignores_unknown_names():
+    response = client.get("/events/month/2023/12",
                           params={"uid": "UID 2", "fields": "uid,bogus"})
     assert response.status_code == 200
     events = response.json()
@@ -453,9 +463,9 @@ def test_read_events_in_year_month_with_fields_ignores_unknown_names():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month_with_empty_fields_is_noop():
-    baseline = client.get("/events/in/2023/12", params={"uid": "UID 2"})
-    response = client.get("/events/in/2023/12",
+def test_read_events_month_with_empty_fields_is_noop():
+    baseline = client.get("/events/month/2023/12", params={"uid": "UID 2"})
+    response = client.get("/events/month/2023/12",
                           params={"uid": "UID 2", "fields": ""})
     assert response.status_code == 200
     assert response.json() == baseline.json()
@@ -463,8 +473,8 @@ def test_read_events_in_year_month_with_empty_fields_is_noop():
 
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
-def test_read_events_in_year_month_with_fields_keeps_cache_headers():
-    response = client.get("/events/in/2023/12",
+def test_read_events_month_with_fields_keeps_cache_headers():
+    response = client.get("/events/month/2023/12",
                           params={"uid": "UID 2", "fields": "uid"})
     assert response.status_code == 200
     assert "Last-Modified" in response.headers

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -249,6 +249,16 @@ def test_read_events_with_keyword():
 @patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.main.IcalEventRequest", MockICalEventRequest)
 def test_read_events_today():
+    response = client.get("/events/day/today")
+    assert response.status_code == 200
+    events = response.json()
+    assert isinstance(events, list)
+    assert "description" in events[0]
+
+
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+def test_read_events_today_legacy_path_still_works():
     response = client.get("/events/today")
     assert response.status_code == 200
     events = response.json()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -370,7 +370,7 @@ def test_normalize_event_params_shares_cache_key_across_equivalent_uid():
         {"ym": ["202312"], "keyword": None, "uid": "UID 2"})
     empty = normalize_event_params({"ym": ["202312"], "keyword": None, "uid": ""})
 
-    # /events/summary omits the "uid" key entirely rather than passing None
+    # /summary/events omits the "uid" key entirely rather than passing None
     no_uid_key = normalize_event_params({"ym": ["202312"], "keyword": None})
 
     cache = EventRequestCache()
@@ -552,7 +552,7 @@ def test_read_events_fromto_year_month_invalid_legacy_path_still_works():
 def test_read_events_summary(mock_get_groups_from_icalendar):
     mock_get_groups_from_icalendar.return_value = []
 
-    response = client.get("/events/summary")
+    response = client.get("/summary/events")
     assert response.status_code == 200
     assert response.headers["Cache-Control"] == "public, max-age=3600"
     assert "Last-Modified" in response.headers
@@ -583,6 +583,20 @@ def test_read_events_summary(mock_get_groups_from_icalendar):
     assert heatmap_by_period["2010-01"] == 0
 
 
+@patch("app.main.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.main.IcalEventRequest", MockICalEventRequest)
+@patch("app.main.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.main.get_groups_from_icalendar")
+def test_read_events_summary_legacy_path_still_works(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/events/summary")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["from_year"] == 2010
+    assert data["granularity"] == "month"
+
+
 class MockConnpassGroupRequestNewerLastModified(MockConnpassGroupRequest):
     def get_last_modified(self):
         return datetime.fromtimestamp(999999, timezone.utc)
@@ -597,7 +611,7 @@ def test_read_events_summary_last_modified_reflects_newer_groups(
         mock_get_groups_from_icalendar):
     mock_get_groups_from_icalendar.return_value = []
 
-    response = client.get("/events/summary")
+    response = client.get("/summary/events")
     assert response.status_code == 200
 
     expected = datetime.fromtimestamp(999999, timezone.utc) \
@@ -630,7 +644,7 @@ def test_read_events_summary_uses_extended_ttls(mock_get_groups_from_icalendar):
     mock_get_groups_from_icalendar.return_value = []
     MockConnpassEventRequestCapturingTTL.received_cache_ttl = []
 
-    response = client.get("/events/summary")
+    response = client.get("/summary/events")
     assert response.status_code == 200
 
     # The low-level connpass cache_ttl (24h) must reach every


### PR DESCRIPTION
## Summary
- Replaces the `in`-disambiguator and range path shapes with meaningful resource-type segments: `/events/year/{year}`, `/events/month/{year}/{month}`, `/events/day/{year}/{month}/{day}`, `/events/day/today`, `/events/range/from/{from_year}/{from_month}/to/{to_year}/{to_month}`.
- Moves the aggregate summary endpoint out of the `/events/*` namespace to `/summary/events`, since it returns a distinct `EventsSummary` model rather than a list of `Event`, and simplifies its operation_id from `summary_events_by_year` to `summary_events` (it always covers 2010–present, not one year).
- `/events/week/this` and `/events/week/next` are unchanged — already a good design.
- All 6 superseded paths (`/events/today`, `/events/in/{year}[/{month}[/{day}]]`, `/events/from/.../to/...`, `/events/summary`) keep working, now marked `deprecated=True` in the OpenAPI schema, until the next major update.
- MCP tool exposure (`/mcp`) is unaffected — canonical operation_ids move to the new routes automatically; `_legacy` operation_ids are excluded from `include_operations`.

## Test plan
- [x] `pytest` — 97 passed
- [x] New tests: legacy routes marked `deprecated` in `/openapi.json`; MCP tool list excludes all `_legacy` operation_ids
- [x] Existing behavior tests (uid/keyword/fields filters, cache headers) retargeted to new canonical paths; old paths covered by smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)