### PR TITLE
Add GET /groups/{group_key} and /groups/{group_key}/events

### DIFF
--- a/app/providers/connpass.py
+++ b/app/providers/connpass.py
@@ -52,38 +52,52 @@ class ConnpassEventRequest:
         return events[0]
 
     def get_events(self):
-        params = self.__query_params()
-        params["count"] = self.PAGE_SIZE
-        params["order"] = 2
-        page = 0
         events = []
+        chunk = 0
         while True:
-            params["start"] = page * self.PAGE_SIZE + 1
-            json = self.__fetch_json(params)
-            events += self.__convert_to_events(json['events'])
-            self.total_available = json.get('results_available')
-
-            if json['results_returned'] < self.PAGE_SIZE:
+            chunk_events, results_returned = self.__fetch_chunk(chunk)
+            events += chunk_events
+            if results_returned < self.PAGE_SIZE:
                 break
-            page += 1
+            chunk += 1
 
         if len(self.prefecture) > 0:
             events = list(filter(self.__is_in_pref, events))
 
         return events
 
-    def get_events_page(self, item_start: int, item_count: int):
+    def get_events_page(self, item_start: int, item_count: int, order: str = "desc"):
         """Return events [item_start, item_start + item_count) (1-indexed),
         fetching only as many PAGE_SIZE-aligned chunks as needed to cover
         that range -- not the whole result set -- while still requesting
         connpass at the exact same chunk boundaries get_events() uses, so
         this shares its cache entries with any full crawl (background or
         otherwise) instead of fragmenting the cache with one entry per
-        distinct page/per_page a caller happens to ask for."""
-        params = self.__query_params()
-        params["count"] = self.PAGE_SIZE
-        params["order"] = 2
+        distinct page/per_page a caller happens to ask for.
 
+        order="desc" fetches directly in connpass's own native order
+        (newest first -- connpass has no true ascending option). order=
+        "asc" mirrors the requested range onto that native descending
+        order, which needs the total result count first: this always
+        touches chunk 0 (typically an existing cache hit, since it's the
+        same chunk 0 every other access to this group also touches)
+        before fetching whichever chunk(s) the mirrored range actually
+        falls in, then reverses the result to hand back ascending order.
+        """
+        if order == "asc":
+            self.__fetch_chunk(0)
+            total = self.total_available or 0
+            if item_start > total:
+                return []
+            desc_start = max(total - item_start - item_count + 2, 1)
+            desc_count = min(item_count, total - item_start + 1)
+            events = self.__fetch_range(desc_start, desc_count)
+            events.reverse()
+            return events
+
+        return self.__fetch_range(item_start, item_count)
+
+    def __fetch_range(self, item_start: int, item_count: int):
         item_end = item_start + item_count - 1
         first_chunk = (item_start - 1) // self.PAGE_SIZE
         last_chunk = (item_end - 1) // self.PAGE_SIZE
@@ -91,12 +105,9 @@ class ConnpassEventRequest:
         events = []
         chunk = first_chunk
         while chunk <= last_chunk:
-            params["start"] = chunk * self.PAGE_SIZE + 1
-            json = self.__fetch_json(params)
-            events += self.__convert_to_events(json['events'])
-            self.total_available = json.get('results_available')
-
-            if json['results_returned'] < self.PAGE_SIZE:
+            chunk_events, results_returned = self.__fetch_chunk(chunk)
+            events += chunk_events
+            if results_returned < self.PAGE_SIZE:
                 break
             chunk += 1
 
@@ -105,6 +116,19 @@ class ConnpassEventRequest:
 
         offset = item_start - 1 - first_chunk * self.PAGE_SIZE
         return events[offset:offset + item_count]
+
+    def __fetch_chunk(self, chunk_index: int):
+        """Fetch one PAGE_SIZE-aligned chunk (connpass's own native,
+        descending order). Returns (events, results_returned) and updates
+        self.total_available as a side effect."""
+        params = self.__query_params()
+        params["count"] = self.PAGE_SIZE
+        params["order"] = 2
+        params["start"] = chunk_index * self.PAGE_SIZE + 1
+
+        json = self.__fetch_json(params)
+        self.total_available = json.get('results_available')
+        return self.__convert_to_events(json['events']), json['results_returned']
 
     def get_last_modified(self):
         return self.last_modified

--- a/app/providers/connpass.py
+++ b/app/providers/connpass.py
@@ -12,12 +12,8 @@ class ConnpassException(Exception):
 
 
 class ConnpassEventRequest:
-    # Connpass's own page size for get_events()'s crawl and the chunk size
-    # get_events_page() aligns to. Keeping this one fixed value means both
-    # methods request identical (subdomain, start, count) params for the
-    # same underlying data, so they always share the same low-level cache
-    # entries regardless of which page size a particular API caller asked
-    # for -- get_events_page() never introduces cache keys of its own.
+    # Fixed so get_events() and get_events_page() always request the same
+    # (subdomain, start, count) params, sharing cache entries between them.
     PAGE_SIZE = 100
 
     def __init__(self, event_id=None, prefecture=None, subdomain=None,
@@ -68,22 +64,9 @@ class ConnpassEventRequest:
 
     def get_events_page(self, item_start: int, item_count: int, order: str = "desc"):
         """Return events [item_start, item_start + item_count) (1-indexed),
-        fetching only as many PAGE_SIZE-aligned chunks as needed to cover
-        that range -- not the whole result set -- while still requesting
-        connpass at the exact same chunk boundaries get_events() uses, so
-        this shares its cache entries with any full crawl (background or
-        otherwise) instead of fragmenting the cache with one entry per
-        distinct page/per_page a caller happens to ask for.
-
-        order="desc" fetches directly in connpass's own native order
-        (newest first -- connpass has no true ascending option). order=
-        "asc" mirrors the requested range onto that native descending
-        order, which needs the total result count first: this always
-        touches chunk 0 (typically an existing cache hit, since it's the
-        same chunk 0 every other access to this group also touches)
-        before fetching whichever chunk(s) the mirrored range actually
-        falls in, then reverses the result to hand back ascending order.
-        """
+        fetching only the PAGE_SIZE-aligned chunks that cover it.
+        order="desc" is connpass's native order; "asc" mirrors the range
+        onto it (needs the total count first) and reverses the result."""
         if order == "asc":
             self.__fetch_chunk(0)
             total = self.total_available or 0
@@ -118,9 +101,7 @@ class ConnpassEventRequest:
         return events[offset:offset + item_count]
 
     def __fetch_chunk(self, chunk_index: int):
-        """Fetch one PAGE_SIZE-aligned chunk (connpass's own native,
-        descending order). Returns (events, results_returned) and updates
-        self.total_available as a side effect."""
+        """Fetch one PAGE_SIZE-aligned chunk; returns (events, results_returned)."""
         params = self.__query_params()
         params["count"] = self.PAGE_SIZE
         params["order"] = 2
@@ -134,9 +115,7 @@ class ConnpassEventRequest:
         return self.last_modified
 
     def get_total_available(self):
-        """Total results matching the query's filters (subdomain/ym/ymd/
-        keyword) -- only meaningful after get_events()/get_events_page()
-        has been called."""
+        """Total results matching the query's filters; set after get_events()/get_events_page()."""
         return self.total_available
 
     def __query_params(self):

--- a/app/providers/connpass.py
+++ b/app/providers/connpass.py
@@ -12,10 +12,18 @@ class ConnpassException(Exception):
 
 
 class ConnpassEventRequest:
+    # Connpass's own page size for get_events()'s crawl and the chunk size
+    # get_events_page() aligns to. Keeping this one fixed value means both
+    # methods request identical (subdomain, start, count) params for the
+    # same underlying data, so they always share the same low-level cache
+    # entries regardless of which page size a particular API caller asked
+    # for -- get_events_page() never introduces cache keys of its own.
+    PAGE_SIZE = 100
+
     def __init__(self, event_id=None, prefecture=None, subdomain=None,
                  ym=None, ymd=None, keyword=None, cache=None,
                  api_key=None, user_agent=None, cache_ttl=3600,
-                 skip_cache=False, start=None, count=None):
+                 skip_cache=False):
         self.url = "https://connpass.com/api/v2/events/"
         self.api_key = api_key
         self.event_id = event_id
@@ -34,10 +42,6 @@ class ConnpassEventRequest:
         self.user_agent = user_agent
         self.cache_ttl = cache_ttl
         self.skip_cache = skip_cache
-        # When both are given, get_events() fetches exactly this one slice
-        # from connpass instead of crawling every page of the result set.
-        self.start = start
-        self.count = count
         self.last_modified = datetime.fromtimestamp(0, timezone.utc)
         self.total_available = None
 
@@ -48,6 +52,70 @@ class ConnpassEventRequest:
         return events[0]
 
     def get_events(self):
+        params = self.__query_params()
+        params["count"] = self.PAGE_SIZE
+        params["order"] = 2
+        page = 0
+        events = []
+        while True:
+            params["start"] = page * self.PAGE_SIZE + 1
+            json = self.__fetch_json(params)
+            events += self.__convert_to_events(json['events'])
+            self.total_available = json.get('results_available')
+
+            if json['results_returned'] < self.PAGE_SIZE:
+                break
+            page += 1
+
+        if len(self.prefecture) > 0:
+            events = list(filter(self.__is_in_pref, events))
+
+        return events
+
+    def get_events_page(self, item_start: int, item_count: int):
+        """Return events [item_start, item_start + item_count) (1-indexed),
+        fetching only as many PAGE_SIZE-aligned chunks as needed to cover
+        that range -- not the whole result set -- while still requesting
+        connpass at the exact same chunk boundaries get_events() uses, so
+        this shares its cache entries with any full crawl (background or
+        otherwise) instead of fragmenting the cache with one entry per
+        distinct page/per_page a caller happens to ask for."""
+        params = self.__query_params()
+        params["count"] = self.PAGE_SIZE
+        params["order"] = 2
+
+        item_end = item_start + item_count - 1
+        first_chunk = (item_start - 1) // self.PAGE_SIZE
+        last_chunk = (item_end - 1) // self.PAGE_SIZE
+
+        events = []
+        chunk = first_chunk
+        while chunk <= last_chunk:
+            params["start"] = chunk * self.PAGE_SIZE + 1
+            json = self.__fetch_json(params)
+            events += self.__convert_to_events(json['events'])
+            self.total_available = json.get('results_available')
+
+            if json['results_returned'] < self.PAGE_SIZE:
+                break
+            chunk += 1
+
+        if len(self.prefecture) > 0:
+            events = list(filter(self.__is_in_pref, events))
+
+        offset = item_start - 1 - first_chunk * self.PAGE_SIZE
+        return events[offset:offset + item_count]
+
+    def get_last_modified(self):
+        return self.last_modified
+
+    def get_total_available(self):
+        """Total results matching the query's filters (subdomain/ym/ymd/
+        keyword) -- only meaningful after get_events()/get_events_page()
+        has been called."""
+        return self.total_available
+
+    def __query_params(self):
         params = {}
         if self.event_id is not None:
             params["event_id"] = self.event_id
@@ -61,63 +129,39 @@ class ConnpassEventRequest:
             params["ymd"] = ",".join(self.ymd)
         if len(self.keyword) > 0:
             params["keyword"] = ",".join(self.keyword)
+        return params
 
-        single_page = self.start is not None and self.count is not None
-        page_size = self.count if single_page else 100
-        params["count"] = page_size
-        params["order"] = 2
-        page = 0
-        events = []
-        while True:
-            params["start"] = self.start if single_page else (page * page_size + 1)
+    def __fetch_json(self, params):
+        json = None
+        last_modified = None
+        if self.cache is not None and not self.skip_cache:
+            response = self.cache.get(params)
+            if response is not None:
+                json = response["json"]
+                last_modified = response["last_modified"]
+        if json is None:
+            # peek() is read regardless of skip_cache: last_modified
+            # should reflect when the data actually last changed, not
+            # merely when it was last checked, so even a forced refresh
+            # still needs the previous value to compare against.
+            # skip_cache only bypasses using the cache to serve a
+            # response, not this comparison.
+            previous = self.cache.peek(params) if self.cache is not None else None
+            try:
+                response = self.__get(params)
+            except ConnpassException as e:
+                raise e
 
-            json = None
-            if self.cache is not None and not self.skip_cache:
-                response = self.cache.get(params)
-                if response is not None:
-                    json = response["json"]
-                    last_modified = response["last_modified"]
-            if json is None:
-                # peek() is read regardless of skip_cache: last_modified
-                # should reflect when the data actually last changed, not
-                # merely when it was last checked, so even a forced refresh
-                # still needs the previous value to compare against.
-                # skip_cache only bypasses using the cache to serve a
-                # response, not this comparison.
-                previous = self.cache.peek(params) if self.cache is not None else None
-                try:
-                    response = self.__get(params)
-                except ConnpassException as e:
-                    raise e
+            json = response.json()
+            last_modified = self.__resolve_last_modified(previous, json)
+            if self.cache is not None:
+                self.cache.set(params, json, last_modified=last_modified,
+                               ex=self.cache_ttl)
 
-                json = response.json()
-                last_modified = self.__resolve_last_modified(previous, json)
-                if self.cache is not None:
-                    self.cache.set(params, json, last_modified=last_modified,
-                                   ex=self.cache_ttl)
-            events += self.__convert_to_events(json['events'])
-            self.total_available = json.get('results_available')
+        if last_modified is not None:
+            self.last_modified = max(self.last_modified, last_modified)
 
-            if last_modified is not None:
-                self.last_modified = max(self.last_modified, last_modified)
-
-            if single_page or json['results_returned'] < page_size:
-                break
-            page += 1
-
-        if len(self.prefecture) > 0:
-            events = list(filter(self.__is_in_pref, events))
-
-        return events
-
-    def get_last_modified(self):
-        return self.last_modified
-
-    def get_total_available(self):
-        """Total results matching the query's filters (subdomain/ym/ymd/
-        keyword), independent of start/count -- only meaningful after
-        get_events() has been called."""
-        return self.total_available
+        return json
 
     def __resolve_last_modified(self, previous, json):
         """Reuse the previously cached last_modified for this page if the

--- a/app/providers/connpass.py
+++ b/app/providers/connpass.py
@@ -15,7 +15,7 @@ class ConnpassEventRequest:
     def __init__(self, event_id=None, prefecture=None, subdomain=None,
                  ym=None, ymd=None, keyword=None, cache=None,
                  api_key=None, user_agent=None, cache_ttl=3600,
-                 skip_cache=False):
+                 skip_cache=False, start=None, count=None):
         self.url = "https://connpass.com/api/v2/events/"
         self.api_key = api_key
         self.event_id = event_id
@@ -34,7 +34,12 @@ class ConnpassEventRequest:
         self.user_agent = user_agent
         self.cache_ttl = cache_ttl
         self.skip_cache = skip_cache
+        # When both are given, get_events() fetches exactly this one slice
+        # from connpass instead of crawling every page of the result set.
+        self.start = start
+        self.count = count
         self.last_modified = datetime.fromtimestamp(0, timezone.utc)
+        self.total_available = None
 
     def get_event(self):
         events = self.get_events()
@@ -57,13 +62,14 @@ class ConnpassEventRequest:
         if len(self.keyword) > 0:
             params["keyword"] = ",".join(self.keyword)
 
-        page_size = 100
+        single_page = self.start is not None and self.count is not None
+        page_size = self.count if single_page else 100
         params["count"] = page_size
         params["order"] = 2
         page = 0
         events = []
         while True:
-            params["start"] = page * page_size + 1
+            params["start"] = self.start if single_page else (page * page_size + 1)
 
             json = None
             if self.cache is not None and not self.skip_cache:
@@ -90,11 +96,12 @@ class ConnpassEventRequest:
                     self.cache.set(params, json, last_modified=last_modified,
                                    ex=self.cache_ttl)
             events += self.__convert_to_events(json['events'])
+            self.total_available = json.get('results_available')
 
             if last_modified is not None:
                 self.last_modified = max(self.last_modified, last_modified)
 
-            if json['results_returned'] < page_size:
+            if single_page or json['results_returned'] < page_size:
                 break
             page += 1
 
@@ -105,6 +112,12 @@ class ConnpassEventRequest:
 
     def get_last_modified(self):
         return self.last_modified
+
+    def get_total_available(self):
+        """Total results matching the query's filters (subdomain/ym/ymd/
+        keyword), independent of start/count -- only meaningful after
+        get_events() has been called."""
+        return self.total_available
 
     def __resolve_last_modified(self, previous, json):
         """Reuse the previously cached last_modified for this page if the

--- a/app/routes.py
+++ b/app/routes.py
@@ -40,6 +40,37 @@ async def read_events(
                                    keyword, uid, fields, if_modified_since)
 
 
+@app.get("/events/group/{group_key}", response_model=List[Event],
+         operation_id="list_events_by_group",
+         summary="List events for a specific group")
+async def read_events_group(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    group_key: str,
+    keyword: str = None,
+    uid: str = None,
+    fields: str = None,
+    if_modified_since: str = Header(None)
+):
+    group = service.find_group_by_key(group_key)
+    if group is None:
+        raise HTTPException(status_code=404,
+                            detail=f"Group '{group_key}' not found")
+
+    days = service.config["recent_days"] if "recent_days" in service.config else 90
+    now = datetime.now()
+    dt_from = now - timedelta(days=days)
+    dt_to = now + timedelta(days=days)
+    ym = year_month_range(dt_from.year, dt_from.month, dt_to.year, dt_to.month)
+
+    events, last_modified = service.get_events(
+        {"ym": ym, "keyword": keyword, "uid": uid, "group_key": group_key},
+        background_tasks)
+
+    return build_list_response(response, events, Event, last_modified,
+                               fields, if_modified_since)
+
+
 @app.get("/events/day/today", response_model=List[Event],
          operation_id="list_events_today",
          summary="List today's events")
@@ -537,6 +568,7 @@ async def refresh_events(
 
 mcp = FastApiMCP(app, include_operations=[
     "list_events",
+    "list_events_by_group",
     "list_events_today",
     "list_events_this_week",
     "list_events_next_week",

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import BackgroundTasks, Path, HTTPException, Depends, Header
+from fastapi import BackgroundTasks, Path, Query, HTTPException, Depends, Header
 from fastapi.responses import RedirectResponse, Response, JSONResponse
 from fastapi_mcp import FastApiMCP
 from . import service
@@ -349,13 +349,24 @@ def filter_model_fields(items, model, fields: str = None):
 
 
 def build_list_response(response: Response, items, model, last_modified,
-                        fields: str = None, if_modified_since: str = None):
+                        fields: str = None, if_modified_since: str = None,
+                        page: int = None, per_page: int = None):
     headers = {"Cache-Control": LIST_CACHE_CONTROL}
     if last_modified is not None:
         headers["Last-Modified"] = format_last_modified(last_modified)
 
     if is_not_modified(if_modified_since, last_modified):
         return Response(status_code=304, headers=headers)
+
+    if page is not None and per_page is not None:
+        total = len(items)
+        total_pages = (total + per_page - 1) // per_page if total > 0 else 0
+        start = (page - 1) * per_page
+        items = items[start:start + per_page]
+        headers["X-Total-Count"] = str(total)
+        headers["X-Page"] = str(page)
+        headers["X-Per-Page"] = str(per_page)
+        headers["X-Total-Pages"] = str(total_pages)
 
     filtered = filter_model_fields(items, model, fields)
     if filtered is None:
@@ -426,6 +437,8 @@ async def read_group_events(
     keyword: str = None,
     uid: str = None,
     fields: str = None,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=200),
     if_modified_since: str = Header(None)
 ):
     if service.find_group_source(group_key) is None:
@@ -433,14 +446,16 @@ async def read_group_events(
                             detail=f"Group '{group_key}' not found")
 
     # Unlike the date-scoped endpoints under /events, this URL carries no
-    # period of its own, so it returns the group's full history rather
-    # than silently applying the recent_days default.
+    # period of its own, so it targets the group's full history rather
+    # than silently applying the recent_days default -- paginated (default
+    # 50/page) to keep the response size bounded.
     events, last_modified = service.get_events(
         {"keyword": keyword, "uid": uid, "group_key": group_key},
         background_tasks)
 
     return build_list_response(response, events, Event, last_modified,
-                               fields, if_modified_since)
+                               fields, if_modified_since,
+                               page=page, per_page=per_page)
 
 
 @app.get("/summary/events", response_model=EventsSummary,

--- a/app/routes.py
+++ b/app/routes.py
@@ -52,8 +52,7 @@ async def read_events_group(
     fields: str = None,
     if_modified_since: str = Header(None)
 ):
-    group = service.find_group_by_key(group_key)
-    if group is None:
+    if service.find_group_source(group_key) is None:
         raise HTTPException(status_code=404,
                             detail=f"Group '{group_key}' not found")
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -384,6 +384,38 @@ async def read_groups(
                                fields, if_modified_since)
 
 
+@app.get("/groups/{group_key}", response_model=Group,
+         operation_id="get_group",
+         summary="Get a single community group")
+async def read_group(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    group_key: str,
+    fields: str = None,
+    if_modified_since: str = Header(None)
+):
+    groups, last_modified = service.get_groups({}, background_tasks)
+    group = next((g for g in groups if g.key == group_key), None)
+    if group is None:
+        raise HTTPException(status_code=404,
+                            detail=f"Group '{group_key}' not found")
+
+    headers = {"Cache-Control": LIST_CACHE_CONTROL}
+    if last_modified is not None:
+        headers["Last-Modified"] = format_last_modified(last_modified)
+
+    if is_not_modified(if_modified_since, last_modified):
+        return Response(status_code=304, headers=headers)
+
+    filtered = filter_model_fields([group], Group, fields)
+    if filtered is None:
+        for key, value in headers.items():
+            response.headers[key] = value
+        return group
+
+    return JSONResponse(content=filtered[0], headers=headers)
+
+
 @app.get("/groups/{group_key}/events", response_model=List[Event],
          operation_id="list_group_events",
          summary="List events for a specific group")
@@ -572,6 +604,7 @@ mcp = FastApiMCP(app, include_operations=[
     "list_events_by_day",
     "list_events_by_range",
     "list_groups",
+    "get_group",
     "list_group_events",
 ])
 mcp.mount_http()

--- a/app/routes.py
+++ b/app/routes.py
@@ -350,7 +350,12 @@ def filter_model_fields(items, model, fields: str = None):
 
 def build_list_response(response: Response, items, model, last_modified,
                         fields: str = None, if_modified_since: str = None,
-                        page: int = None, per_page: int = None):
+                        total: int = None, page: int = None,
+                        per_page: int = None):
+    """items must already be the exact page to return -- this only adds
+    the X-Total-* pagination headers, it doesn't slice anything itself,
+    since where slicing happens (locally vs. pushed upstream) depends on
+    how items was fetched."""
     headers = {"Cache-Control": LIST_CACHE_CONTROL}
     if last_modified is not None:
         headers["Last-Modified"] = format_last_modified(last_modified)
@@ -358,11 +363,8 @@ def build_list_response(response: Response, items, model, last_modified,
     if is_not_modified(if_modified_since, last_modified):
         return Response(status_code=304, headers=headers)
 
-    if page is not None and per_page is not None:
-        total = len(items)
+    if total is not None and page is not None and per_page is not None:
         total_pages = (total + per_page - 1) // per_page if total > 0 else 0
-        start = (page - 1) * per_page
-        items = items[start:start + per_page]
         headers["X-Total-Count"] = str(total)
         headers["X-Page"] = str(page)
         headers["X-Per-Page"] = str(per_page)
@@ -448,14 +450,16 @@ async def read_group_events(
     # Unlike the date-scoped endpoints under /events, this URL carries no
     # period of its own, so it targets the group's full history rather
     # than silently applying the recent_days default -- paginated (default
-    # 50/page) to keep the response size bounded.
-    events, last_modified = service.get_events(
-        {"keyword": keyword, "uid": uid, "group_key": group_key},
-        background_tasks)
+    # 50/page) to keep the response size bounded. get_group_events_page
+    # paginates directly against connpass when no keyword/uid/chapter
+    # filtering is needed, rather than crawling the group's entire
+    # history just to slice it locally.
+    events, total, last_modified = service.get_group_events_page(
+        group_key, keyword, uid, page, per_page, background_tasks)
 
     return build_list_response(response, events, Event, last_modified,
                                fields, if_modified_since,
-                               page=page, per_page=per_page)
+                               total=total, page=page, per_page=per_page)
 
 
 @app.get("/summary/events", response_model=EventsSummary,

--- a/app/routes.py
+++ b/app/routes.py
@@ -56,14 +56,11 @@ async def read_events_group(
         raise HTTPException(status_code=404,
                             detail=f"Group '{group_key}' not found")
 
-    days = service.config["recent_days"] if "recent_days" in service.config else 90
-    now = datetime.now()
-    dt_from = now - timedelta(days=days)
-    dt_to = now + timedelta(days=days)
-    ym = year_month_range(dt_from.year, dt_from.month, dt_to.year, dt_to.month)
-
+    # Unlike the date-scoped endpoints, this URL carries no period of its
+    # own, so it returns the group's full history rather than silently
+    # applying the recent_days default.
     events, last_modified = service.get_events(
-        {"ym": ym, "keyword": keyword, "uid": uid, "group_key": group_key},
+        {"keyword": keyword, "uid": uid, "group_key": group_key},
         background_tasks)
 
     return build_list_response(response, events, Event, last_modified,

--- a/app/routes.py
+++ b/app/routes.py
@@ -442,14 +442,16 @@ async def read_group_events(
     order: Literal["asc", "desc"] = "desc",
     if_modified_since: str = Header(None)
 ):
-    if service.find_group_source(group_key) is None:
+    source = service.find_group_source(group_key)
+    if source is None:
         raise HTTPException(status_code=404,
                             detail=f"Group '{group_key}' not found")
 
     # No date scope here (unlike /events/*), so this targets the group's
     # full history, paginated (default 50/page, order defaults to "desc").
     events, total, last_modified = service.get_group_events_page(
-        group_key, keyword, uid, page, per_page, order, background_tasks)
+        group_key, keyword, uid, page, per_page, order, background_tasks,
+        source=source)
 
     return build_list_response(response, events, Event, last_modified,
                                fields, if_modified_since,

--- a/app/routes.py
+++ b/app/routes.py
@@ -352,10 +352,8 @@ def build_list_response(response: Response, items, model, last_modified,
                         fields: str = None, if_modified_since: str = None,
                         total: int = None, page: int = None,
                         per_page: int = None):
-    """items must already be the exact page to return -- this only adds
-    the X-Total-* pagination headers, it doesn't slice anything itself,
-    since where slicing happens (locally vs. pushed upstream) depends on
-    how items was fetched."""
+    """items must already be the exact page to return; this only adds
+    the X-Total-* headers, it doesn't slice anything itself."""
     headers = {"Cache-Control": LIST_CACHE_CONTROL}
     if last_modified is not None:
         headers["Last-Modified"] = format_last_modified(last_modified)
@@ -448,15 +446,8 @@ async def read_group_events(
         raise HTTPException(status_code=404,
                             detail=f"Group '{group_key}' not found")
 
-    # Unlike the date-scoped endpoints under /events, this URL carries no
-    # period of its own, so it targets the group's full history rather
-    # than silently applying the recent_days default -- paginated (default
-    # 50/page) to keep the response size bounded. get_group_events_page
-    # paginates directly against connpass when no keyword/uid/chapter
-    # filtering is needed, rather than crawling the group's entire
-    # history just to slice it locally. order defaults to "desc" (newest
-    # first) since that's connpass's own native order -- cheapest for the
-    # common case of just browsing a group's recent activity.
+    # No date scope here (unlike /events/*), so this targets the group's
+    # full history, paginated (default 50/page, order defaults to "desc").
     events, total, last_modified = service.get_group_events_page(
         group_key, keyword, uid, page, per_page, order, background_tasks)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -40,33 +40,6 @@ async def read_events(
                                    keyword, uid, fields, if_modified_since)
 
 
-@app.get("/events/group/{group_key}", response_model=List[Event],
-         operation_id="list_events_by_group",
-         summary="List events for a specific group")
-async def read_events_group(
-    response: Response,
-    background_tasks: BackgroundTasks,
-    group_key: str,
-    keyword: str = None,
-    uid: str = None,
-    fields: str = None,
-    if_modified_since: str = Header(None)
-):
-    if service.find_group_source(group_key) is None:
-        raise HTTPException(status_code=404,
-                            detail=f"Group '{group_key}' not found")
-
-    # Unlike the date-scoped endpoints, this URL carries no period of its
-    # own, so it returns the group's full history rather than silently
-    # applying the recent_days default.
-    events, last_modified = service.get_events(
-        {"keyword": keyword, "uid": uid, "group_key": group_key},
-        background_tasks)
-
-    return build_list_response(response, events, Event, last_modified,
-                               fields, if_modified_since)
-
-
 @app.get("/events/day/today", response_model=List[Event],
          operation_id="list_events_today",
          summary="List today's events")
@@ -411,6 +384,33 @@ async def read_groups(
                                fields, if_modified_since)
 
 
+@app.get("/groups/{group_key}/events", response_model=List[Event],
+         operation_id="list_group_events",
+         summary="List events for a specific group")
+async def read_group_events(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    group_key: str,
+    keyword: str = None,
+    uid: str = None,
+    fields: str = None,
+    if_modified_since: str = Header(None)
+):
+    if service.find_group_source(group_key) is None:
+        raise HTTPException(status_code=404,
+                            detail=f"Group '{group_key}' not found")
+
+    # Unlike the date-scoped endpoints under /events, this URL carries no
+    # period of its own, so it returns the group's full history rather
+    # than silently applying the recent_days default.
+    events, last_modified = service.get_events(
+        {"keyword": keyword, "uid": uid, "group_key": group_key},
+        background_tasks)
+
+    return build_list_response(response, events, Event, last_modified,
+                               fields, if_modified_since)
+
+
 @app.get("/summary/events", response_model=EventsSummary,
          operation_id="summary_events",
          summary="Get yearly event summary with group highlights and activity heatmap")
@@ -564,7 +564,6 @@ async def refresh_events(
 
 mcp = FastApiMCP(app, include_operations=[
     "list_events",
-    "list_events_by_group",
     "list_events_today",
     "list_events_this_week",
     "list_events_next_week",
@@ -573,5 +572,6 @@ mcp = FastApiMCP(app, include_operations=[
     "list_events_by_day",
     "list_events_by_range",
     "list_groups",
+    "list_group_events",
 ])
 mcp.mount_http()

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Literal
 from fastapi import BackgroundTasks, Path, Query, HTTPException, Depends, Header
 from fastapi.responses import RedirectResponse, Response, JSONResponse
 from fastapi_mcp import FastApiMCP
@@ -441,6 +441,7 @@ async def read_group_events(
     fields: str = None,
     page: int = Query(1, ge=1),
     per_page: int = Query(50, ge=1, le=200),
+    order: Literal["asc", "desc"] = "desc",
     if_modified_since: str = Header(None)
 ):
     if service.find_group_source(group_key) is None:
@@ -453,9 +454,11 @@ async def read_group_events(
     # 50/page) to keep the response size bounded. get_group_events_page
     # paginates directly against connpass when no keyword/uid/chapter
     # filtering is needed, rather than crawling the group's entire
-    # history just to slice it locally.
+    # history just to slice it locally. order defaults to "desc" (newest
+    # first) since that's connpass's own native order -- cheapest for the
+    # common case of just browsing a group's recent activity.
     events, total, last_modified = service.get_group_events_page(
-        group_key, keyword, uid, page, per_page, background_tasks)
+        group_key, keyword, uid, page, per_page, order, background_tasks)
 
     return build_list_response(response, events, Event, last_modified,
                                fields, if_modified_since,

--- a/app/service.py
+++ b/app/service.py
@@ -279,7 +279,8 @@ def request_events_for_group(source: dict, group_key, ym, ymd, cache_ttl: int,
 
 def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
                           order: str = "desc",
-                          background_tasks: BackgroundTasks = None
+                          background_tasks: BackgroundTasks = None,
+                          source: Optional[dict] = None
                           ) -> Tuple[List[Event], int, Optional[datetime]]:
     """Serve one page of a group's events, sorted by started_at.
 
@@ -291,7 +292,7 @@ def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
     Returns (events_for_page, total_count, last_modified)."""
     global cache
 
-    source = find_group_source(group_key)
+    source = source or find_group_source(group_key)
     if source is None:
         return [], 0, None
 

--- a/app/service.py
+++ b/app/service.py
@@ -288,9 +288,11 @@ def request_events_for_group(source: dict, group_key, ym, ymd, cache_ttl: int,
 
 
 def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
+                          order: str = "desc",
                           background_tasks: BackgroundTasks = None
                           ) -> Tuple[List[Event], int, Optional[datetime]]:
-    """Serve one page of a group's events.
+    """Serve one page of a group's events, sorted by started_at according
+    to order ("asc" or "desc").
 
     When the group is a plain connpass group (not a chapter) and no
     keyword/uid filter is requested, paginates directly against connpass
@@ -299,11 +301,16 @@ def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
     slice, at the same page boundaries a full crawl would use, so this
     shares cache entries with any full crawl instead of adding one cache
     entry per distinct page/per_page a caller happens to request.
+    order="desc" is connpass's own native order (no extra cost);
+    order="asc" needs the total result count first to mirror the
+    requested range onto that native order (see get_events_page()).
+
     Chapters and keyword/uid filters can only be applied correctly once
     the full, unpaginated result set is known (a chapter's title match
     and the keyword/uid filters can each drop items unpredictably), so
     those fall back to the existing get_events() cached/background-
-    refreshed full fetch and slice locally.
+    refreshed full fetch (always ascending) and slice locally, reversing
+    first if descending order was requested.
 
     Returns (events_for_page, total_count, last_modified).
     """
@@ -326,7 +333,7 @@ def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
                                  cache=cache, api_key=connpass_api_key,
                                  user_agent=user_agent)
         item_start = (page - 1) * per_page + 1
-        events = r.get_events_page(item_start, per_page)
+        events = r.get_events_page(item_start, per_page, order=order)
         for event in events:
             if event.keywords is None:
                 event.keywords = keyword_extractor.extract(event)
@@ -335,6 +342,8 @@ def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
     events, last_modified = get_events(
         {"keyword": keyword, "uid": uid, "group_key": group_key},
         background_tasks)
+    if order == "desc":
+        events = list(reversed(events))
     start = (page - 1) * per_page
     return events[start:start + per_page], len(events), last_modified
 

--- a/app/service.py
+++ b/app/service.py
@@ -296,10 +296,7 @@ def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
     if source is None:
         return [], 0, None
 
-    # Blank/whitespace-only values are effectively "no filter" (see
-    # normalize_event_params), but arrive here as non-None strings from
-    # query params -- normalize before deciding on the fast path so an
-    # empty ?keyword= or ?uid= doesn't force the slow full-fetch path.
+    # Blank query params arrive as "" here, not None; treat them the same.
     keyword = (keyword.strip() or None) if keyword is not None else None
     uid = (uid.strip() or None) if uid is not None else None
 

--- a/app/service.py
+++ b/app/service.py
@@ -39,7 +39,18 @@ def normalize_event_params(params):
         uid = uid.strip()
         if uid == "":
             uid = None
-    return {**params, "uid": uid}
+
+    result = {**params, "uid": uid}
+
+    if "group_key" in params:
+        group_key = params.get("group_key")
+        if group_key is not None:
+            group_key = group_key.strip()
+            if group_key == "":
+                group_key = None
+        result["group_key"] = group_key
+
+    return result
 
 
 def get_events(params,
@@ -101,6 +112,7 @@ def request_events(params, cache_ttl: int = None,
     ymd = params["ymd"] if "ymd" in params else None
     keyword = params["keyword"] if "keyword" in params else None
     uid = params["uid"] if "uid" in params else None
+    group_key = params.get("group_key")
     connpass_cache_ttl = cache_ttl if cache_ttl is not None else 3600
 
     user_agent = get_user_agent(config)
@@ -108,54 +120,61 @@ def request_events(params, cache_ttl: int = None,
     events = []
     last_modified = datetime.fromtimestamp(0, timezone.utc)
     try:
-        if "scope" in config and "prefecture" in config["scope"]:
-            prefecture = config["scope"]["prefecture"]
-            r = ConnpassEventRequest(prefecture=prefecture,
-                                     ym=ym, ymd=ymd, cache=cache,
-                                     api_key=connpass_api_key,
-                                     user_agent=user_agent,
-                                     cache_ttl=connpass_cache_ttl,
-                                     skip_cache=force_refresh
-                                     )
-            events += r.get_events()
-            last_modified = max(last_modified, r.get_last_modified())
+        if group_key is not None:
+            group = find_group_by_key(group_key)
+            if group is not None:
+                events, last_modified = request_events_for_group(
+                    group, ym, ymd, connpass_cache_ttl, force_refresh)
 
-        plain_subdomains, chapters = split_connpass_scope(config)
-        subdomain = merged_connpass_subdomains(plain_subdomains, chapters)
-
-        if len(subdomain) > 0:
-            r = ConnpassEventRequest(subdomain=subdomain,
-                                     ym=ym, ymd=ymd, cache=cache,
-                                     api_key=connpass_api_key,
-                                     user_agent=user_agent,
-                                     cache_ttl=connpass_cache_ttl,
-                                     skip_cache=force_refresh
-                                     )
-            events += partition_and_relabel_chapter_events(
-                r.get_events(), chapters)
-            last_modified = max(last_modified, r.get_last_modified())
-
-        if "scope" in config and "icalendar" in config["scope"]:
-            icalendar = config["scope"]["icalendar"]
-            for group in icalendar:
-                key = group["key"]
-                name = group["name"]
-                image_url = group.get("image_url")
-                group_url = group.get("group_url")
-                ical_url = group["ical_url"]
-                r = IcalEventRequest(url=ical_url,
-                                     key=key, name=name,
-                                     image_url=image_url, group_url=group_url,
-                                     ym=ym, ymd=ymd, cache=cache)
+        else:
+            if "scope" in config and "prefecture" in config["scope"]:
+                prefecture = config["scope"]["prefecture"]
+                r = ConnpassEventRequest(prefecture=prefecture,
+                                         ym=ym, ymd=ymd, cache=cache,
+                                         api_key=connpass_api_key,
+                                         user_agent=user_agent,
+                                         cache_ttl=connpass_cache_ttl,
+                                         skip_cache=force_refresh
+                                         )
                 events += r.get_events()
                 last_modified = max(last_modified, r.get_last_modified())
 
-        if "scope" in config and "archives" in config["scope"]:
-            for url in get_archive_urls(config):
-                r = ArchiveIndexRequest(url=url,
-                                        ym=ym, ymd=ymd, cache=cache)
-                events += r.get_events()
+            plain_subdomains, chapters = split_connpass_scope(config)
+            subdomain = merged_connpass_subdomains(plain_subdomains, chapters)
+
+            if len(subdomain) > 0:
+                r = ConnpassEventRequest(subdomain=subdomain,
+                                         ym=ym, ymd=ymd, cache=cache,
+                                         api_key=connpass_api_key,
+                                         user_agent=user_agent,
+                                         cache_ttl=connpass_cache_ttl,
+                                         skip_cache=force_refresh
+                                         )
+                events += partition_and_relabel_chapter_events(
+                    r.get_events(), chapters)
                 last_modified = max(last_modified, r.get_last_modified())
+
+            if "scope" in config and "icalendar" in config["scope"]:
+                icalendar = config["scope"]["icalendar"]
+                for group in icalendar:
+                    key = group["key"]
+                    name = group["name"]
+                    image_url = group.get("image_url")
+                    group_url = group.get("group_url")
+                    ical_url = group["ical_url"]
+                    r = IcalEventRequest(url=ical_url,
+                                         key=key, name=name,
+                                         image_url=image_url, group_url=group_url,
+                                         ym=ym, ymd=ymd, cache=cache)
+                    events += r.get_events()
+                    last_modified = max(last_modified, r.get_last_modified())
+
+            if "scope" in config and "archives" in config["scope"]:
+                for url in get_archive_urls(config):
+                    r = ArchiveIndexRequest(url=url,
+                                            ym=ym, ymd=ymd, cache=cache)
+                    events += r.get_events()
+                    last_modified = max(last_modified, r.get_last_modified())
 
     except ConnpassException as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
@@ -179,6 +198,65 @@ def request_events(params, cache_ttl: int = None,
 
     if uid is not None:
         events = [ev for ev in events if ev.uid == uid]
+
+    return events, last_modified
+
+
+def find_group_by_key(group_key) -> Optional[Group]:
+    """Resolve a group_key against the configured groups (scope.connpass
+    plain/chapter, scope.icalendar, scope.archives). Groups only discovered
+    via the prefecture-wide connpass search are not included here, since
+    they aren't part of the configured scope."""
+    groups, _ = get_groups({})
+    return next((g for g in groups if g.key == group_key), None)
+
+
+def request_events_for_group(group: Group, ym, ymd, cache_ttl: int,
+                             force_refresh: bool = False
+                             ) -> Tuple[List[Event], datetime]:
+    """Fetch events for a single already-resolved group, scoping the
+    upstream request to just that group's source instead of the full
+    configured scope."""
+    global cache
+
+    user_agent = get_user_agent(config)
+    events = []
+    last_modified = datetime.fromtimestamp(0, timezone.utc)
+
+    if group.ical_url is not None:
+        r = IcalEventRequest(url=group.ical_url, key=group.key, name=group.title,
+                             image_url=group.image_url, group_url=group.url,
+                             ym=ym, ymd=ymd, cache=cache)
+        events += r.get_events()
+        last_modified = max(last_modified, r.get_last_modified())
+
+    elif group.archive_source is not None:
+        # Archive indexes have no per-group query -- filter client-side.
+        for url in get_archive_urls(config):
+            r = ArchiveIndexRequest(url=url, ym=ym, ymd=ymd, cache=cache)
+            events += [ev for ev in r.get_events() if ev.group_key == group.key]
+            last_modified = max(last_modified, r.get_last_modified())
+
+    else:
+        # connpass-sourced (plain group or chapter). A chapter's key is a
+        # virtual key distinct from the real subdomain it's carved out of.
+        _, chapters = split_connpass_scope(config)
+        chapter_entry = next((c for c in chapters if c["key"] == group.key), None)
+        subdomain = chapter_entry["subdomain"] if chapter_entry is not None else group.key
+        keyword = chapter_entry["title_keyword"] if chapter_entry is not None else None
+
+        r = ConnpassEventRequest(subdomain=[subdomain], keyword=keyword,
+                                 ym=ym, ymd=ymd, cache=cache,
+                                 api_key=connpass_api_key, user_agent=user_agent,
+                                 cache_ttl=cache_ttl, skip_cache=force_refresh)
+        fetched = r.get_events()
+        # partition_and_relabel_chapter_events still enforces the exact
+        # title match: connpass's keyword search also matches description/
+        # address text, so the keyword param above only narrows the
+        # upstream fetch -- it doesn't replace this correctness check.
+        events += (partition_and_relabel_chapter_events(fetched, [chapter_entry])
+                   if chapter_entry is not None else fetched)
+        last_modified = max(last_modified, r.get_last_modified())
 
     return events, last_modified
 

--- a/app/service.py
+++ b/app/service.py
@@ -287,6 +287,57 @@ def request_events_for_group(source: dict, group_key, ym, ymd, cache_ttl: int,
     return events, last_modified
 
 
+def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
+                          background_tasks: BackgroundTasks = None
+                          ) -> Tuple[List[Event], int, Optional[datetime]]:
+    """Serve one page of a group's events.
+
+    When the group is a plain connpass group (not a chapter) and no
+    keyword/uid filter is requested, paginates directly against connpass
+    -- one API call for exactly this page, using connpass's own result
+    count for the total -- instead of crawling the group's entire
+    history just to slice it locally. Chapters and keyword/uid filters
+    can only be applied correctly once the full, unpaginated result set
+    is known (a chapter's title match and the keyword/uid filters can
+    each drop items unpredictably), so those fall back to the existing
+    get_events() cached/background-refreshed full fetch and slice
+    locally.
+
+    Returns (events_for_page, total_count, last_modified).
+    """
+    global cache
+
+    source = find_group_source(group_key)
+    if source is None:
+        return [], 0, None
+
+    can_paginate_upstream = (
+        source["type"] == "connpass"
+        and source["chapter_entry"] is None
+        and keyword is None
+        and uid is None
+    )
+
+    if can_paginate_upstream:
+        user_agent = get_user_agent(config)
+        r = ConnpassEventRequest(subdomain=[source["subdomain"]],
+                                 cache=cache, api_key=connpass_api_key,
+                                 user_agent=user_agent,
+                                 start=(page - 1) * per_page + 1,
+                                 count=per_page)
+        events = r.get_events()
+        for event in events:
+            if event.keywords is None:
+                event.keywords = keyword_extractor.extract(event)
+        return events, r.get_total_available() or 0, r.get_last_modified()
+
+    events, last_modified = get_events(
+        {"keyword": keyword, "uid": uid, "group_key": group_key},
+        background_tasks)
+    start = (page - 1) * per_page
+    return events[start:start + per_page], len(events), last_modified
+
+
 def get_groups(params,
                background_tasks: BackgroundTasks = None
                ) -> Tuple[List[Group], datetime]:

--- a/app/service.py
+++ b/app/service.py
@@ -296,6 +296,13 @@ def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
     if source is None:
         return [], 0, None
 
+    # Blank/whitespace-only values are effectively "no filter" (see
+    # normalize_event_params), but arrive here as non-None strings from
+    # query params -- normalize before deciding on the fast path so an
+    # empty ?keyword= or ?uid= doesn't force the slow full-fetch path.
+    keyword = (keyword.strip() or None) if keyword is not None else None
+    uid = (uid.strip() or None) if uid is not None else None
+
     can_paginate_upstream = (
         source["type"] == "connpass"
         and source["chapter_entry"] is None

--- a/app/service.py
+++ b/app/service.py
@@ -294,14 +294,16 @@ def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
 
     When the group is a plain connpass group (not a chapter) and no
     keyword/uid filter is requested, paginates directly against connpass
-    -- one API call for exactly this page, using connpass's own result
-    count for the total -- instead of crawling the group's entire
-    history just to slice it locally. Chapters and keyword/uid filters
-    can only be applied correctly once the full, unpaginated result set
-    is known (a chapter's title match and the keyword/uid filters can
-    each drop items unpredictably), so those fall back to the existing
-    get_events() cached/background-refreshed full fetch and slice
-    locally.
+    via ConnpassEventRequest.get_events_page() -- fetching only as many
+    of connpass's own 100-item pages as needed to cover the requested
+    slice, at the same page boundaries a full crawl would use, so this
+    shares cache entries with any full crawl instead of adding one cache
+    entry per distinct page/per_page a caller happens to request.
+    Chapters and keyword/uid filters can only be applied correctly once
+    the full, unpaginated result set is known (a chapter's title match
+    and the keyword/uid filters can each drop items unpredictably), so
+    those fall back to the existing get_events() cached/background-
+    refreshed full fetch and slice locally.
 
     Returns (events_for_page, total_count, last_modified).
     """
@@ -322,10 +324,9 @@ def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
         user_agent = get_user_agent(config)
         r = ConnpassEventRequest(subdomain=[source["subdomain"]],
                                  cache=cache, api_key=connpass_api_key,
-                                 user_agent=user_agent,
-                                 start=(page - 1) * per_page + 1,
-                                 count=per_page)
-        events = r.get_events()
+                                 user_agent=user_agent)
+        item_start = (page - 1) * per_page + 1
+        events = r.get_events_page(item_start, per_page)
         for event in events:
             if event.keywords is None:
                 event.keywords = keyword_extractor.extract(event)

--- a/app/service.py
+++ b/app/service.py
@@ -121,10 +121,10 @@ def request_events(params, cache_ttl: int = None,
     last_modified = datetime.fromtimestamp(0, timezone.utc)
     try:
         if group_key is not None:
-            group = find_group_by_key(group_key)
-            if group is not None:
+            source = find_group_source(group_key)
+            if source is not None:
                 events, last_modified = request_events_for_group(
-                    group, ym, ymd, connpass_cache_ttl, force_refresh)
+                    source, group_key, ym, ymd, connpass_cache_ttl, force_refresh)
 
         else:
             if "scope" in config and "prefecture" in config["scope"]:
@@ -202,61 +202,87 @@ def request_events(params, cache_ttl: int = None,
     return events, last_modified
 
 
-def find_group_by_key(group_key) -> Optional[Group]:
-    """Resolve a group_key against the configured groups (scope.connpass
-    plain/chapter, scope.icalendar, scope.archives). Groups only discovered
-    via the prefecture-wide connpass search are not included here, since
-    they aren't part of the configured scope."""
-    groups, _ = get_groups({})
-    return next((g for g in groups if g.key == group_key), None)
+def find_group_source(group_key) -> Optional[dict]:
+    """Resolve group_key to its configured source using only config.yaml --
+    scope.connpass (plain/chapter) and scope.icalendar identity is fully
+    known from config, so no connpass API call is needed to check those.
+    Only scope.archives requires fetching the archive index itself (not
+    connpass) to confirm the key exists there, since archive group
+    identity isn't declared in config.yaml.
+
+    Returns a dict describing the source, or None if group_key doesn't
+    match any configured group. Groups only discoverable via the
+    prefecture-wide connpass search are intentionally excluded."""
+    global cache
+
+    plain_subdomains, chapters = split_connpass_scope(config)
+
+    chapter_entry = next((c for c in chapters if c["key"] == group_key), None)
+    if chapter_entry is not None:
+        return {"type": "connpass", "subdomain": chapter_entry["subdomain"],
+                "keyword": chapter_entry["title_keyword"],
+                "chapter_entry": chapter_entry}
+
+    if group_key in plain_subdomains:
+        return {"type": "connpass", "subdomain": group_key, "keyword": None,
+                "chapter_entry": None}
+
+    if "scope" in config and "icalendar" in config["scope"]:
+        for entry in config["scope"]["icalendar"]:
+            if entry["key"] == group_key:
+                return {"type": "icalendar", "ical_url": entry["ical_url"],
+                        "name": entry["name"],
+                        "group_url": entry.get("group_url")}
+
+    if "scope" in config and "archives" in config["scope"]:
+        for url in get_archive_urls(config):
+            r = ArchiveIndexRequest(url=url, cache=cache)
+            if any(g.key == group_key for g in r.get_groups()):
+                return {"type": "archive"}
+
+    return None
 
 
-def request_events_for_group(group: Group, ym, ymd, cache_ttl: int,
+def request_events_for_group(source: dict, group_key, ym, ymd, cache_ttl: int,
                              force_refresh: bool = False
                              ) -> Tuple[List[Event], datetime]:
-    """Fetch events for a single already-resolved group, scoping the
-    upstream request to just that group's source instead of the full
-    configured scope."""
+    """Fetch events for a group whose source was already resolved by
+    find_group_source(), scoping the upstream request to just that
+    group's source instead of the full configured scope."""
     global cache
 
     user_agent = get_user_agent(config)
     events = []
     last_modified = datetime.fromtimestamp(0, timezone.utc)
 
-    if group.ical_url is not None:
-        r = IcalEventRequest(url=group.ical_url, key=group.key, name=group.title,
-                             image_url=group.image_url, group_url=group.url,
-                             ym=ym, ymd=ymd, cache=cache)
-        events += r.get_events()
-        last_modified = max(last_modified, r.get_last_modified())
-
-    elif group.archive_source is not None:
-        # Archive indexes have no per-group query -- filter client-side.
-        for url in get_archive_urls(config):
-            r = ArchiveIndexRequest(url=url, ym=ym, ymd=ymd, cache=cache)
-            events += [ev for ev in r.get_events() if ev.group_key == group.key]
-            last_modified = max(last_modified, r.get_last_modified())
-
-    else:
-        # connpass-sourced (plain group or chapter). A chapter's key is a
-        # virtual key distinct from the real subdomain it's carved out of.
-        _, chapters = split_connpass_scope(config)
-        chapter_entry = next((c for c in chapters if c["key"] == group.key), None)
-        subdomain = chapter_entry["subdomain"] if chapter_entry is not None else group.key
-        keyword = chapter_entry["title_keyword"] if chapter_entry is not None else None
-
-        r = ConnpassEventRequest(subdomain=[subdomain], keyword=keyword,
+    if source["type"] == "connpass":
+        r = ConnpassEventRequest(subdomain=[source["subdomain"]],
+                                 keyword=source["keyword"],
                                  ym=ym, ymd=ymd, cache=cache,
                                  api_key=connpass_api_key, user_agent=user_agent,
                                  cache_ttl=cache_ttl, skip_cache=force_refresh)
         fetched = r.get_events()
         # partition_and_relabel_chapter_events still enforces the exact
         # title match: connpass's keyword search also matches description/
-        # address text, so the keyword param above only narrows the
+        # address text, so source["keyword"] above only narrows the
         # upstream fetch -- it doesn't replace this correctness check.
-        events += (partition_and_relabel_chapter_events(fetched, [chapter_entry])
-                   if chapter_entry is not None else fetched)
+        events += (partition_and_relabel_chapter_events(fetched, [source["chapter_entry"]])
+                   if source["chapter_entry"] is not None else fetched)
         last_modified = max(last_modified, r.get_last_modified())
+
+    elif source["type"] == "icalendar":
+        r = IcalEventRequest(url=source["ical_url"], key=group_key,
+                             name=source["name"], group_url=source["group_url"],
+                             ym=ym, ymd=ymd, cache=cache)
+        events += r.get_events()
+        last_modified = max(last_modified, r.get_last_modified())
+
+    elif source["type"] == "archive":
+        # Archive indexes have no per-group query -- filter client-side.
+        for url in get_archive_urls(config):
+            r = ArchiveIndexRequest(url=url, ym=ym, ymd=ymd, cache=cache)
+            events += [ev for ev in r.get_events() if ev.group_key == group_key]
+            last_modified = max(last_modified, r.get_last_modified())
 
     return events, last_modified
 

--- a/app/service.py
+++ b/app/service.py
@@ -203,16 +203,10 @@ def request_events(params, cache_ttl: int = None,
 
 
 def find_group_source(group_key) -> Optional[dict]:
-    """Resolve group_key to its configured source using only config.yaml --
-    scope.connpass (plain/chapter) and scope.icalendar identity is fully
-    known from config, so no connpass API call is needed to check those.
-    Only scope.archives requires fetching the archive index itself (not
-    connpass) to confirm the key exists there, since archive group
-    identity isn't declared in config.yaml.
-
-    Returns a dict describing the source, or None if group_key doesn't
-    match any configured group. Groups only discoverable via the
-    prefecture-wide connpass search are intentionally excluded."""
+    """Resolve group_key to its configured source using only config.yaml;
+    only scope.archives needs an actual fetch (its own index), since
+    archive group identity isn't declared in config.yaml. Returns None if
+    group_key isn't configured (prefecture-only discoveries don't count)."""
     global cache
 
     plain_subdomains, chapters = split_connpass_scope(config)
@@ -246,9 +240,7 @@ def find_group_source(group_key) -> Optional[dict]:
 def request_events_for_group(source: dict, group_key, ym, ymd, cache_ttl: int,
                              force_refresh: bool = False
                              ) -> Tuple[List[Event], datetime]:
-    """Fetch events for a group whose source was already resolved by
-    find_group_source(), scoping the upstream request to just that
-    group's source instead of the full configured scope."""
+    """Fetch events for a group whose source was resolved by find_group_source()."""
     global cache
 
     user_agent = get_user_agent(config)
@@ -262,10 +254,8 @@ def request_events_for_group(source: dict, group_key, ym, ymd, cache_ttl: int,
                                  api_key=connpass_api_key, user_agent=user_agent,
                                  cache_ttl=cache_ttl, skip_cache=force_refresh)
         fetched = r.get_events()
-        # partition_and_relabel_chapter_events still enforces the exact
-        # title match: connpass's keyword search also matches description/
-        # address text, so source["keyword"] above only narrows the
-        # upstream fetch -- it doesn't replace this correctness check.
+        # keyword only narrows the upstream fetch; the exact title match
+        # below still runs since connpass's keyword search is broader.
         events += (partition_and_relabel_chapter_events(fetched, [source["chapter_entry"]])
                    if source["chapter_entry"] is not None else fetched)
         last_modified = max(last_modified, r.get_last_modified())
@@ -291,29 +281,14 @@ def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
                           order: str = "desc",
                           background_tasks: BackgroundTasks = None
                           ) -> Tuple[List[Event], int, Optional[datetime]]:
-    """Serve one page of a group's events, sorted by started_at according
-    to order ("asc" or "desc").
+    """Serve one page of a group's events, sorted by started_at.
 
-    When the group is a plain connpass group (not a chapter) and no
-    keyword/uid filter is requested, paginates directly against connpass
-    via ConnpassEventRequest.get_events_page() -- fetching only as many
-    of connpass's own 100-item pages as needed to cover the requested
-    slice, at the same page boundaries a full crawl would use, so this
-    shares cache entries with any full crawl instead of adding one cache
-    entry per distinct page/per_page a caller happens to request.
-    order="desc" is connpass's own native order (no extra cost);
-    order="asc" needs the total result count first to mirror the
-    requested range onto that native order (see get_events_page()).
+    Paginates directly against connpass (see get_events_page()) for a
+    plain connpass group with no keyword/uid filter. Chapters and
+    keyword/uid filters need the full result set to apply correctly, so
+    those fall back to get_events() and slice locally.
 
-    Chapters and keyword/uid filters can only be applied correctly once
-    the full, unpaginated result set is known (a chapter's title match
-    and the keyword/uid filters can each drop items unpredictably), so
-    those fall back to the existing get_events() cached/background-
-    refreshed full fetch (always ascending) and slice locally, reversing
-    first if descending order was requested.
-
-    Returns (events_for_page, total_count, last_modified).
-    """
+    Returns (events_for_page, total_count, last_modified)."""
     global cache
 
     source = find_group_source(group_key)

--- a/tests/test_connpass.py
+++ b/tests/test_connpass.py
@@ -266,10 +266,8 @@ class TestConnpassEventRequest(unittest.TestCase):
         self.assertEqual(seen_starts, [1, 101])
 
     def test_get_events_page_shares_cache_keys_with_get_events(self):
-        # The whole point of chunking to PAGE_SIZE boundaries is that a
-        # small get_events_page() request and a full get_events() crawl
-        # hit the exact same cache entries -- verify the params sent for
-        # the first chunk are identical either way.
+        # get_events_page() and get_events() must send identical params
+        # for the same chunk, so they share cache entries.
         mock_cache = MagicMock()
         mock_cache.get.return_value = None
         mock_get = MagicMock(
@@ -305,10 +303,8 @@ class TestConnpassEventRequest(unittest.TestCase):
                          list(reversed([e.event_id for e in descending])))
 
     def test_get_events_page_ascending_reuses_chunk_zero_when_range_fits(self):
-        # A real cache (not a bare mock) so the redundant chunk-0 request
-        # this needs to learn the total is an actual cache hit, exactly
-        # as it would be in production -- proving no second live fetch
-        # happens for a range that chunk 0 already covers.
+        # Real cache, not a bare mock: the redundant chunk-0 fetch to
+        # learn the total should be a cache hit, not a second live call.
         real_cache = EventRequestCache(prefix="test_page_asc_reuse_")
 
         connpass_request = ConnpassEventRequest(subdomain=['test'], cache=real_cache)

--- a/tests/test_connpass.py
+++ b/tests/test_connpass.py
@@ -288,6 +288,66 @@ class TestConnpassEventRequest(unittest.TestCase):
 
         self.assertEqual(crawl_params, page_params)
 
+    def test_get_events_page_ascending_is_reverse_of_descending(self):
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        def make_request():
+            r = ConnpassEventRequest(subdomain=['test'], cache=mock_cache)
+            r._ConnpassEventRequest__get = MagicMock(
+                return_value=self._make_page_response(5, 5, 5))
+            return r
+
+        descending = make_request().get_events_page(1, 5, order="desc")
+        ascending = make_request().get_events_page(1, 5, order="asc")
+
+        self.assertEqual([e.event_id for e in ascending],
+                         list(reversed([e.event_id for e in descending])))
+
+    def test_get_events_page_ascending_reuses_chunk_zero_when_range_fits(self):
+        # A real cache (not a bare mock) so the redundant chunk-0 request
+        # this needs to learn the total is an actual cache hit, exactly
+        # as it would be in production -- proving no second live fetch
+        # happens for a range that chunk 0 already covers.
+        real_cache = EventRequestCache(prefix="test_page_asc_reuse_")
+
+        connpass_request = ConnpassEventRequest(subdomain=['test'], cache=real_cache)
+        mock_get = MagicMock(return_value=self._make_page_response(5, 5, 5))
+        connpass_request._ConnpassEventRequest__get = mock_get
+
+        # Ascending item 1 (oldest) maps to descending position 5, which
+        # already lives in chunk 0 -- no second chunk fetch needed.
+        events = connpass_request.get_events_page(1, 1, order="asc")
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].event_id, 4)
+        mock_get.assert_called_once()
+
+    def test_get_events_page_ascending_spans_multiple_chunks_when_needed(self):
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        connpass_request = ConnpassEventRequest(subdomain=['test'], cache=mock_cache)
+        responses = {
+            1: self._make_page_response(100, 100, 150),   # chunk 0
+            101: self._make_page_response(50, 50, 150),   # chunk 1
+        }
+        seen_starts = []
+
+        def fake_get(params):
+            seen_starts.append(params['start'])
+            return responses[params['start']]
+
+        connpass_request._ConnpassEventRequest__get = MagicMock(side_effect=fake_get)
+
+        # Ascending items 1-10 (oldest 10 of 150) map to descending
+        # positions 141-150, which live in chunk 1 -- must touch chunk 0
+        # (to learn the total) and chunk 1 (for the actual range).
+        events = connpass_request.get_events_page(1, 10, order="asc")
+
+        self.assertEqual(len(events), 10)
+        self.assertEqual(sorted(set(seen_starts)), [1, 101])
+
     def _make_event_response(self, event_id):
         mock_response = MagicMock()
         mock_response.json.return_value = {

--- a/tests/test_connpass.py
+++ b/tests/test_connpass.py
@@ -185,6 +185,60 @@ class TestConnpassEventRequest(unittest.TestCase):
         # ...but the freshly fetched result must still be written back.
         mock_cache.set.assert_called_once()
 
+    def test_get_events_with_start_and_count_fetches_single_page(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'events': [
+                {
+                    'id': 123,
+                    'title': 'Test Event',
+                    'catch': None,
+                    'hash_tag': None,
+                    'url': 'https://test.connpass.com',
+                    'started_at': '2020-01-01T00:00:00+09:00',
+                    'ended_at': '2020-01-01T00:00:00+09:00',
+                    'updated_at': '2020-01-01T00:00:00+09:00',
+                    'open_status': 'preopen',
+                    'limit': 100,
+                    'accepted': 50,
+                    'waiting': 50,
+                    'owner_id': 1234,
+                    'owner_nickname': 'test',
+                    'owner_display_name': 'Test',
+                    'place': None,
+                    'address': None,
+                    'lat': None,
+                    'lon': None,
+                    'description': None,
+                    'event_type': 'participation',
+                    'group': None
+                }
+            ],
+            # A full page (results_returned == count) would make the
+            # crawl-everything loop continue to a second page -- this must
+            # not happen when start/count are given.
+            'results_returned': 20,
+            'results_available': 42
+        }
+
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        connpass_request = ConnpassEventRequest(
+            subdomain=['test'], cache=mock_cache, start=21, count=20)
+        mock_get = MagicMock(return_value=mock_response)
+        connpass_request._ConnpassEventRequest__get = mock_get
+
+        events = connpass_request.get_events()
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(connpass_request.get_total_available(), 42)
+
+        mock_get.assert_called_once()
+        sent_params = mock_get.call_args[0][0]
+        self.assertEqual(sent_params['start'], 21)
+        self.assertEqual(sent_params['count'], 20)
+
     def _make_event_response(self, event_id):
         mock_response = MagicMock()
         mock_response.json.return_value = {

--- a/tests/test_connpass.py
+++ b/tests/test_connpass.py
@@ -185,13 +185,13 @@ class TestConnpassEventRequest(unittest.TestCase):
         # ...but the freshly fetched result must still be written back.
         mock_cache.set.assert_called_once()
 
-    def test_get_events_with_start_and_count_fetches_single_page(self):
+    def _make_page_response(self, num_events, results_returned, results_available):
         mock_response = MagicMock()
         mock_response.json.return_value = {
             'events': [
                 {
-                    'id': 123,
-                    'title': 'Test Event',
+                    'id': i,
+                    'title': f'Test Event {i}',
                     'catch': None,
                     'hash_tag': None,
                     'url': 'https://test.connpass.com',
@@ -213,31 +213,80 @@ class TestConnpassEventRequest(unittest.TestCase):
                     'event_type': 'participation',
                     'group': None
                 }
+                for i in range(num_events)
             ],
-            # A full page (results_returned == count) would make the
-            # crawl-everything loop continue to a second page -- this must
-            # not happen when start/count are given.
-            'results_returned': 20,
-            'results_available': 42
+            'results_returned': results_returned,
+            'results_available': results_available
         }
+        return mock_response
 
+    def test_get_events_page_fetches_one_chunk_when_range_fits(self):
         mock_cache = MagicMock()
         mock_cache.get.return_value = None
 
-        connpass_request = ConnpassEventRequest(
-            subdomain=['test'], cache=mock_cache, start=21, count=20)
-        mock_get = MagicMock(return_value=mock_response)
+        connpass_request = ConnpassEventRequest(subdomain=['test'], cache=mock_cache)
+        mock_get = MagicMock(
+            return_value=self._make_page_response(100, 100, 250))
         connpass_request._ConnpassEventRequest__get = mock_get
 
-        events = connpass_request.get_events()
+        # Items 1-10 fit entirely within the first PAGE_SIZE=100 chunk.
+        events = connpass_request.get_events_page(1, 10)
 
-        self.assertEqual(len(events), 1)
-        self.assertEqual(connpass_request.get_total_available(), 42)
-
+        self.assertEqual(len(events), 10)
+        self.assertEqual(connpass_request.get_total_available(), 250)
         mock_get.assert_called_once()
         sent_params = mock_get.call_args[0][0]
-        self.assertEqual(sent_params['start'], 21)
-        self.assertEqual(sent_params['count'], 20)
+        self.assertEqual(sent_params['start'], 1)
+        self.assertEqual(sent_params['count'], ConnpassEventRequest.PAGE_SIZE)
+
+    def test_get_events_page_fetches_only_chunks_the_range_spans(self):
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        connpass_request = ConnpassEventRequest(subdomain=['test'], cache=mock_cache)
+        responses = [
+            self._make_page_response(100, 100, 250),  # chunk 0: items 1-100
+            self._make_page_response(100, 100, 250),  # chunk 1: items 101-200
+        ]
+        seen_starts = []
+
+        def fake_get(params):
+            seen_starts.append(params['start'])
+            return responses[len(seen_starts) - 1]
+
+        mock_get = MagicMock(side_effect=fake_get)
+        connpass_request._ConnpassEventRequest__get = mock_get
+
+        # Items 95-114 span chunk 0 (1-100) and chunk 1 (101-200), but must
+        # not reach chunk 2 (201-300).
+        events = connpass_request.get_events_page(95, 20)
+
+        self.assertEqual(len(events), 20)
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(seen_starts, [1, 101])
+
+    def test_get_events_page_shares_cache_keys_with_get_events(self):
+        # The whole point of chunking to PAGE_SIZE boundaries is that a
+        # small get_events_page() request and a full get_events() crawl
+        # hit the exact same cache entries -- verify the params sent for
+        # the first chunk are identical either way.
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+        mock_get = MagicMock(
+            return_value=self._make_page_response(1, 1, 1))
+
+        crawl_request = ConnpassEventRequest(subdomain=['test'], cache=mock_cache)
+        crawl_request._ConnpassEventRequest__get = mock_get
+        crawl_request.get_events()
+        crawl_params = mock_get.call_args[0][0]
+
+        mock_get.reset_mock()
+        page_request = ConnpassEventRequest(subdomain=['test'], cache=mock_cache)
+        page_request._ConnpassEventRequest__get = mock_get
+        page_request.get_events_page(1, 10)
+        page_params = mock_get.call_args[0][0]
+
+        self.assertEqual(crawl_params, page_params)
 
     def _make_event_response(self, event_id):
         mock_response = MagicMock()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -683,8 +683,7 @@ def test_read_group_events_connpass_plain_with_uid_falls_back_to_full_fetch():
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_plain_blank_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_connpass_plain_with_blank_filters_still_uses_fast_path():
-    # Blank keyword/uid are effectively "no filter" and must not defeat
-    # the upstream-pagination fast path.
+    # Blank keyword/uid must not defeat the upstream-pagination fast path.
     response = client.get("/groups/jagyamanashi/events",
                           params={"keyword": "", "uid": "  ", "per_page": 1})
     assert response.status_code == 200

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,10 +29,15 @@ class MockConnpassEventRequest:
     def get_events(self):
         return Event.from_json(self._fixed_json())
 
-    def get_events_page(self, item_start, item_count):
+    def get_events_page(self, item_start, item_count, order="desc"):
         MockConnpassEventRequest.page_requests.append(
-            {"item_start": item_start, "item_count": item_count})
+            {"item_start": item_start, "item_count": item_count, "order": order})
+        # _fixed_json() is in ascending (oldest-first) order; simulate
+        # connpass's native descending order the same way the real
+        # ConnpassEventRequest.get_events_page() treats "desc" as native.
         events = Event.from_json(self._fixed_json())
+        if order == "desc":
+            events = list(reversed(events))
         return events[item_start - 1:item_start - 1 + item_count]
 
     def get_total_available(self):
@@ -661,7 +666,7 @@ def test_read_group_events_connpass_plain():
     assert "keyword" not in req
 
     assert MockConnpassEventRequest.page_requests == [
-        {"item_start": 1, "item_count": 50}]
+        {"item_start": 1, "item_count": 50, "order": "desc"}]
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_plain_filtered_"))
@@ -701,12 +706,14 @@ def test_read_group_events_default_pagination():
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_slice_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_pagination_slices_pages():
+    # Default order is "desc" (native/newest-first): reversed, page 2 of
+    # 1-per-page is the earlier event, UID 1.
     response = client.get("/groups/jagyamanashi/events",
                           params={"per_page": 1, "page": 2})
     assert response.status_code == 200
     events = response.json()
     assert len(events) == 1
-    assert events[0]["uid"] == "UID 2"
+    assert events[0]["uid"] == "UID 1"
 
     assert response.headers["X-Total-Count"] == "2"
     assert response.headers["X-Page"] == "2"
@@ -715,7 +722,7 @@ def test_read_group_events_pagination_slices_pages():
 
     assert len(MockConnpassEventRequest.requests) == 1
     assert MockConnpassEventRequest.page_requests == [
-        {"item_start": 2, "item_count": 1}]
+        {"item_start": 2, "item_count": 1, "order": "desc"}]
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_oob_"))
@@ -740,14 +747,47 @@ def test_read_group_events_pagination_rejects_invalid_params():
     response = client.get("/groups/jagyamanashi/events", params={"per_page": 201})
     assert response.status_code == 422
 
+    response = client.get("/groups/jagyamanashi/events", params={"order": "sideways"})
+    assert response.status_code == 422
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_order_asc_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+def test_read_group_events_ascending_order():
+    # order=asc reverses connpass's native descending order, so page 1 is
+    # the oldest event, UID 1.
+    response = client.get("/groups/jagyamanashi/events",
+                          params={"per_page": 1, "order": "asc"})
+    assert response.status_code == 200
+    events = response.json()
+    assert len(events) == 1
+    assert events[0]["uid"] == "UID 1"
+
+    assert MockConnpassEventRequest.page_requests == [
+        {"item_start": 1, "item_count": 1, "order": "asc"}]
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_chapter_desc_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+def test_read_group_events_chapter_descending_order():
+    # Chapters fall back to get_events() (always ascending); order=desc
+    # must reverse that result locally.
+    response = client.get("/groups/soracomug-yamanashi/events",
+                          params={"order": "desc"})
+    assert response.status_code == 200
+    events = response.json()
+    started_ats = [e["started_at"] for e in events]
+    assert started_ats == sorted(started_ats, reverse=True)
+
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_fields_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_pagination_headers_kept_with_fields():
+    # Default order "desc": page 1 of 1-per-page is the newest event, UID 2.
     response = client.get("/groups/jagyamanashi/events",
                           params={"per_page": 1, "fields": "uid"})
     assert response.status_code == 200
-    assert response.json() == [{"uid": "UID 1"}]
+    assert response.json() == [{"uid": "UID 2"}]
     assert response.headers["X-Total-Count"] == "2"
     assert response.headers["X-Per-Page"] == "1"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -680,6 +680,19 @@ def test_read_group_events_connpass_plain_with_uid_falls_back_to_full_fetch():
     assert MockConnpassEventRequest.page_requests == []
 
 
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_plain_blank_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+def test_read_group_events_connpass_plain_with_blank_filters_still_uses_fast_path():
+    # Blank keyword/uid are effectively "no filter" and must not defeat
+    # the upstream-pagination fast path.
+    response = client.get("/groups/jagyamanashi/events",
+                          params={"keyword": "", "uid": "  ", "per_page": 1})
+    assert response.status_code == 200
+
+    assert MockConnpassEventRequest.page_requests == [
+        {"item_start": 1, "item_count": 1, "order": "desc"}]
+
+
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_default_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_default_pagination():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,6 +24,8 @@ class MockConnpassEventRequest:
 
     def __init__(self, **kwargs):
         MockConnpassEventRequest.requests.append(kwargs)
+        self.start = kwargs.get("start")
+        self.count = kwargs.get("count")
 
     def get_events(self):
         json = [
@@ -77,7 +79,14 @@ class MockConnpassEventRequest:
             }
         ]
         events = Event.from_json(json)
+        # Simulates connpass's own start/count pagination, so tests can
+        # exercise get_group_events_page's upstream-pagination fast path.
+        if self.start is not None and self.count is not None:
+            return events[self.start - 1:self.start - 1 + self.count]
         return events
+
+    def get_total_available(self):
+        return 2
 
     def get_last_modified(self):
         last_modified = datetime.fromtimestamp(123, timezone.utc)
@@ -634,24 +643,46 @@ def test_read_events_fromto_year_month_invalid_legacy_path_still_works():
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_connpass_plain():
     # config.yaml's real plain connpass subdomain, resolved from config
-    # alone -- no connpass groups API call needed
+    # alone -- no connpass groups API call needed. Plain (non-chapter)
+    # group with no keyword/uid filter takes the upstream-pagination fast
+    # path, so exactly one connpass request is made -- no background
+    # refetch, since that path bypasses get_events() entirely.
     response = client.get("/groups/jagyamanashi/events")
     assert response.status_code == 200
     events = response.json()
     assert isinstance(events, list)
 
-    # background_tasks refetches once more after the initial response, so
-    # assert every recorded call was scoped the same way rather than count
+    assert len(MockConnpassEventRequest.requests) == 1
+    req = MockConnpassEventRequest.requests[0]
+    assert req["subdomain"] == ["jagyamanashi"]
+    assert "keyword" not in req
+    assert req["start"] == 1
+    assert req["count"] == 50
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_plain_filtered_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+def test_read_group_events_connpass_plain_with_uid_falls_back_to_full_fetch():
+    # A uid filter can't be applied correctly without the full result set,
+    # so this must fall back to get_events()'s crawl-everything path
+    # (no start/count) rather than the upstream-pagination fast path.
+    response = client.get("/groups/jagyamanashi/events", params={"uid": "UID 2"})
+    assert response.status_code == 200
+    events = response.json()
+    assert len(events) == 1
+    assert events[0]["uid"] == "UID 2"
+
     assert len(MockConnpassEventRequest.requests) >= 1
     for req in MockConnpassEventRequest.requests:
         assert req["subdomain"] == ["jagyamanashi"]
         assert req["keyword"] is None
+        assert req.get("start") is None
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_default_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_default_pagination():
-    # MockConnpassEventRequest always returns exactly 2 events (UID 1, UID 2)
+    # MockConnpassEventRequest always reports 2 events available (UID 1, UID 2)
     response = client.get("/groups/jagyamanashi/events")
     assert response.status_code == 200
     events = response.json()
@@ -677,6 +708,10 @@ def test_read_group_events_pagination_slices_pages():
     assert response.headers["X-Page"] == "2"
     assert response.headers["X-Per-Page"] == "1"
     assert response.headers["X-Total-Pages"] == "2"
+
+    assert len(MockConnpassEventRequest.requests) == 1
+    assert MockConnpassEventRequest.requests[0]["start"] == 2
+    assert MockConnpassEventRequest.requests[0]["count"] == 1
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_oob_"))
@@ -717,7 +752,9 @@ def test_read_group_events_pagination_headers_kept_with_fields():
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_connpass_chapter():
     # config.yaml defines chapter key "soracomug-yamanashi" carved out of the
-    # real subdomain "soracomug-tokyo" via title_keyword "山梨"
+    # real subdomain "soracomug-tokyo" via title_keyword "山梨". A chapter's
+    # title match can only be applied after fetching everything, so this
+    # falls back to get_events()'s crawl-everything path (no start/count).
     response = client.get("/groups/soracomug-yamanashi/events")
     assert response.status_code == 200
 
@@ -725,6 +762,7 @@ def test_read_group_events_connpass_chapter():
     for req in MockConnpassEventRequest.requests:
         assert req["subdomain"] == ["soracomug-tokyo"]
         assert req["keyword"] == "山梨"
+        assert req.get("start") is None
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_ical_"))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,14 +21,25 @@ client = TestClient(app)
 
 class MockConnpassEventRequest:
     requests = []
+    page_requests = []
 
     def __init__(self, **kwargs):
         MockConnpassEventRequest.requests.append(kwargs)
-        self.start = kwargs.get("start")
-        self.count = kwargs.get("count")
 
     def get_events(self):
-        json = [
+        return Event.from_json(self._fixed_json())
+
+    def get_events_page(self, item_start, item_count):
+        MockConnpassEventRequest.page_requests.append(
+            {"item_start": item_start, "item_count": item_count})
+        events = Event.from_json(self._fixed_json())
+        return events[item_start - 1:item_start - 1 + item_count]
+
+    def get_total_available(self):
+        return 2
+
+    def _fixed_json(self):
+        return [
             {
                 "uid": "UID 1",
                 "event_id": 1,
@@ -78,15 +89,6 @@ class MockConnpassEventRequest:
                 "lon": ""
             }
         ]
-        events = Event.from_json(json)
-        # Simulates connpass's own start/count pagination, so tests can
-        # exercise get_group_events_page's upstream-pagination fast path.
-        if self.start is not None and self.count is not None:
-            return events[self.start - 1:self.start - 1 + self.count]
-        return events
-
-    def get_total_available(self):
-        return 2
 
     def get_last_modified(self):
         last_modified = datetime.fromtimestamp(123, timezone.utc)
@@ -248,6 +250,7 @@ def mock_archive_index_request():
 @pytest.fixture(autouse=True)
 def mock_connpass_event_request_calls():
     MockConnpassEventRequest.requests = []
+    MockConnpassEventRequest.page_requests = []
     yield
 
 
@@ -656,8 +659,9 @@ def test_read_group_events_connpass_plain():
     req = MockConnpassEventRequest.requests[0]
     assert req["subdomain"] == ["jagyamanashi"]
     assert "keyword" not in req
-    assert req["start"] == 1
-    assert req["count"] == 50
+
+    assert MockConnpassEventRequest.page_requests == [
+        {"item_start": 1, "item_count": 50}]
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_plain_filtered_"))
@@ -665,7 +669,7 @@ def test_read_group_events_connpass_plain():
 def test_read_group_events_connpass_plain_with_uid_falls_back_to_full_fetch():
     # A uid filter can't be applied correctly without the full result set,
     # so this must fall back to get_events()'s crawl-everything path
-    # (no start/count) rather than the upstream-pagination fast path.
+    # rather than the upstream-pagination fast path.
     response = client.get("/groups/jagyamanashi/events", params={"uid": "UID 2"})
     assert response.status_code == 200
     events = response.json()
@@ -676,7 +680,7 @@ def test_read_group_events_connpass_plain_with_uid_falls_back_to_full_fetch():
     for req in MockConnpassEventRequest.requests:
         assert req["subdomain"] == ["jagyamanashi"]
         assert req["keyword"] is None
-        assert req.get("start") is None
+    assert MockConnpassEventRequest.page_requests == []
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_default_"))
@@ -710,8 +714,8 @@ def test_read_group_events_pagination_slices_pages():
     assert response.headers["X-Total-Pages"] == "2"
 
     assert len(MockConnpassEventRequest.requests) == 1
-    assert MockConnpassEventRequest.requests[0]["start"] == 2
-    assert MockConnpassEventRequest.requests[0]["count"] == 1
+    assert MockConnpassEventRequest.page_requests == [
+        {"item_start": 2, "item_count": 1}]
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_oob_"))
@@ -754,7 +758,7 @@ def test_read_group_events_connpass_chapter():
     # config.yaml defines chapter key "soracomug-yamanashi" carved out of the
     # real subdomain "soracomug-tokyo" via title_keyword "山梨". A chapter's
     # title match can only be applied after fetching everything, so this
-    # falls back to get_events()'s crawl-everything path (no start/count).
+    # falls back to get_events()'s crawl-everything path.
     response = client.get("/groups/soracomug-yamanashi/events")
     assert response.status_code == 200
 
@@ -762,7 +766,7 @@ def test_read_group_events_connpass_chapter():
     for req in MockConnpassEventRequest.requests:
         assert req["subdomain"] == ["soracomug-tokyo"]
         assert req["keyword"] == "山梨"
-        assert req.get("start") is None
+    assert MockConnpassEventRequest.page_requests == []
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_ical_"))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -648,6 +648,71 @@ def test_read_group_events_connpass_plain():
         assert req["keyword"] is None
 
 
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_default_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+def test_read_group_events_default_pagination():
+    # MockConnpassEventRequest always returns exactly 2 events (UID 1, UID 2)
+    response = client.get("/groups/jagyamanashi/events")
+    assert response.status_code == 200
+    events = response.json()
+    assert len(events) == 2
+
+    assert response.headers["X-Total-Count"] == "2"
+    assert response.headers["X-Page"] == "1"
+    assert response.headers["X-Per-Page"] == "50"
+    assert response.headers["X-Total-Pages"] == "1"
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_slice_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+def test_read_group_events_pagination_slices_pages():
+    response = client.get("/groups/jagyamanashi/events",
+                          params={"per_page": 1, "page": 2})
+    assert response.status_code == 200
+    events = response.json()
+    assert len(events) == 1
+    assert events[0]["uid"] == "UID 2"
+
+    assert response.headers["X-Total-Count"] == "2"
+    assert response.headers["X-Page"] == "2"
+    assert response.headers["X-Per-Page"] == "1"
+    assert response.headers["X-Total-Pages"] == "2"
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_oob_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+def test_read_group_events_pagination_out_of_range_page_is_empty():
+    response = client.get("/groups/jagyamanashi/events",
+                          params={"per_page": 1, "page": 99})
+    assert response.status_code == 200
+    assert response.json() == []
+    assert response.headers["X-Total-Count"] == "2"
+    assert response.headers["X-Total-Pages"] == "2"
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_invalid_"))
+def test_read_group_events_pagination_rejects_invalid_params():
+    response = client.get("/groups/jagyamanashi/events", params={"page": 0})
+    assert response.status_code == 422
+
+    response = client.get("/groups/jagyamanashi/events", params={"per_page": 0})
+    assert response.status_code == 422
+
+    response = client.get("/groups/jagyamanashi/events", params={"per_page": 201})
+    assert response.status_code == 422
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_fields_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+def test_read_group_events_pagination_headers_kept_with_fields():
+    response = client.get("/groups/jagyamanashi/events",
+                          params={"per_page": 1, "fields": "uid"})
+    assert response.status_code == 200
+    assert response.json() == [{"uid": "UID 1"}]
+    assert response.headers["X-Total-Count"] == "2"
+    assert response.headers["X-Per-Page"] == "1"
+
+
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_chapter_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_connpass_chapter():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -630,12 +630,12 @@ def test_read_events_fromto_year_month_invalid_legacy_path_still_works():
     assert response.status_code == 400
 
 
-@patch("app.service.cache", EventRequestCache(prefix="test_events_group_plain_"))
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_plain_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
-def test_read_events_group_connpass_plain():
+def test_read_group_events_connpass_plain():
     # config.yaml's real plain connpass subdomain, resolved from config
     # alone -- no connpass groups API call needed
-    response = client.get("/events/group/jagyamanashi")
+    response = client.get("/groups/jagyamanashi/events")
     assert response.status_code == 200
     events = response.json()
     assert isinstance(events, list)
@@ -648,12 +648,12 @@ def test_read_events_group_connpass_plain():
         assert req["keyword"] is None
 
 
-@patch("app.service.cache", EventRequestCache(prefix="test_events_group_chapter_"))
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_chapter_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
-def test_read_events_group_connpass_chapter():
+def test_read_group_events_connpass_chapter():
     # config.yaml defines chapter key "soracomug-yamanashi" carved out of the
     # real subdomain "soracomug-tokyo" via title_keyword "山梨"
-    response = client.get("/events/group/soracomug-yamanashi")
+    response = client.get("/groups/soracomug-yamanashi/events")
     assert response.status_code == 200
 
     assert len(MockConnpassEventRequest.requests) >= 1
@@ -662,11 +662,11 @@ def test_read_events_group_connpass_chapter():
         assert req["keyword"] == "山梨"
 
 
-@patch("app.service.cache", EventRequestCache(prefix="test_events_group_ical_"))
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_ical_"))
 @patch("app.service.IcalEventRequest", MockICalEventRequest)
-def test_read_events_group_icalendar():
+def test_read_group_events_icalendar():
     # config.yaml's real icalendar entry, resolved from config alone
-    response = client.get("/events/group/yamanashi-wordpress-meetup-ical")
+    response = client.get("/groups/yamanashi-wordpress-meetup-ical/events")
     assert response.status_code == 200
 
     assert len(MockICalEventRequest.requests) >= 1
@@ -676,23 +676,23 @@ def test_read_events_group_icalendar():
             "https://www.meetup.com/ja-JP/Yamanashi-WordPress-Meetup/events/ical/"
 
 
-@patch("app.service.cache", EventRequestCache(prefix="test_events_group_archive_"))
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_archive_"))
 @patch("app.service.split_connpass_scope", return_value=([], []))
-def test_read_events_group_archive(mock_split_connpass_scope):
+def test_read_group_events_archive(mock_split_connpass_scope):
     # config.yaml also has a real plain connpass subdomain "yamanashi-web";
     # neutralize scope.connpass here to exercise the archive-only path
     # (archive group identity has no config.yaml equivalent, so it's the
     # one source find_group_source must actually query to confirm a match)
-    response = client.get("/events/group/yamanashi-web")
+    response = client.get("/groups/yamanashi-web/events")
     assert response.status_code == 200
     events = response.json()
     assert len(events) == 1
     assert events[0]["group_key"] == "yamanashi-web"
 
 
-@patch("app.service.cache", EventRequestCache(prefix="test_events_group_404_"))
-def test_read_events_group_not_found():
-    response = client.get("/events/group/no-such-group")
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_404_"))
+def test_read_group_events_not_found():
+    response = client.get("/groups/no-such-group/events")
     assert response.status_code == 404
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,7 @@ from app.service import get_user_agent, get_groups_from_icalendar
 from app.service import request_events, request_groups, get_groups_from_archives
 from app.service import get_archive_urls, preload_archive_indexes
 from app.service import get_events, get_groups, normalize_event_params
-from app.service import find_group_by_key
+from app.service import find_group_source
 from app.service import fetch_events, fetch_groups
 from app.service import split_connpass_scope, partition_and_relabel_chapter_events
 from app.service import get_groups_from_connpass_chapters, merged_connpass_subdomains
@@ -632,13 +632,10 @@ def test_read_events_fromto_year_month_invalid_legacy_path_still_works():
 
 @patch("app.service.cache", EventRequestCache(prefix="test_events_group_plain_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
-@patch("app.service.get_groups_from_icalendar")
-def test_read_events_group_connpass_plain(mock_get_groups_from_icalendar):
-    mock_get_groups_from_icalendar.return_value = []
-
-    # MockConnpassGroupRequest always reports a single plain group, key "Key"
-    response = client.get("/events/group/Key")
+def test_read_events_group_connpass_plain():
+    # config.yaml's real plain connpass subdomain, resolved from config
+    # alone -- no connpass groups API call needed
+    response = client.get("/events/group/jagyamanashi")
     assert response.status_code == 200
     events = response.json()
     assert isinstance(events, list)
@@ -647,17 +644,13 @@ def test_read_events_group_connpass_plain(mock_get_groups_from_icalendar):
     # assert every recorded call was scoped the same way rather than count
     assert len(MockConnpassEventRequest.requests) >= 1
     for req in MockConnpassEventRequest.requests:
-        assert req["subdomain"] == ["Key"]
+        assert req["subdomain"] == ["jagyamanashi"]
         assert req["keyword"] is None
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_events_group_chapter_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
-@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
-@patch("app.service.get_groups_from_icalendar")
-def test_read_events_group_connpass_chapter(mock_get_groups_from_icalendar):
-    mock_get_groups_from_icalendar.return_value = []
-
+def test_read_events_group_connpass_chapter():
     # config.yaml defines chapter key "soracomug-yamanashi" carved out of the
     # real subdomain "soracomug-tokyo" via title_keyword "山梨"
     response = client.get("/events/group/soracomug-yamanashi")
@@ -671,10 +664,8 @@ def test_read_events_group_connpass_chapter(mock_get_groups_from_icalendar):
 
 @patch("app.service.cache", EventRequestCache(prefix="test_events_group_ical_"))
 @patch("app.service.IcalEventRequest", MockICalEventRequest)
-@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
 def test_read_events_group_icalendar():
-    # config.yaml's real icalendar entry, resolved without mocking
-    # get_groups_from_icalendar since it does no network I/O itself
+    # config.yaml's real icalendar entry, resolved from config alone
     response = client.get("/events/group/yamanashi-wordpress-meetup-ical")
     assert response.status_code == 200
 
@@ -686,13 +677,12 @@ def test_read_events_group_icalendar():
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_events_group_archive_"))
-@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
-@patch("app.service.get_groups_from_icalendar")
-def test_read_events_group_archive(mock_get_groups_from_icalendar):
-    mock_get_groups_from_icalendar.return_value = []
-
-    # Archive indexes can't be queried per-group, so this must be filtered
-    # client-side against the mocked archive's fixed event list
+@patch("app.service.split_connpass_scope", return_value=([], []))
+def test_read_events_group_archive(mock_split_connpass_scope):
+    # config.yaml also has a real plain connpass subdomain "yamanashi-web";
+    # neutralize scope.connpass here to exercise the archive-only path
+    # (archive group identity has no config.yaml equivalent, so it's the
+    # one source find_group_source must actually query to confirm a match)
     response = client.get("/events/group/yamanashi-web")
     assert response.status_code == 200
     events = response.json()
@@ -701,24 +691,38 @@ def test_read_events_group_archive(mock_get_groups_from_icalendar):
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_events_group_404_"))
-@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
-@patch("app.service.get_groups_from_icalendar")
-def test_read_events_group_not_found(mock_get_groups_from_icalendar):
-    mock_get_groups_from_icalendar.return_value = []
-
+def test_read_events_group_not_found():
     response = client.get("/events/group/no-such-group")
     assert response.status_code == 404
 
 
-@patch("app.service.cache", EventRequestCache(prefix="test_find_group_by_key_"))
-def test_find_group_by_key():
-    groups = [
-        Group.from_json({"key": "a", "title": "A"}),
-        Group.from_json({"key": "b", "title": "B"}),
-    ]
-    with patch("app.service.get_groups", return_value=(groups, None)):
-        assert find_group_by_key("b").key == "b"
-        assert find_group_by_key("no-such") is None
+def test_find_group_source_connpass_plain():
+    source = find_group_source("jagyamanashi")
+    assert source == {"type": "connpass", "subdomain": "jagyamanashi",
+                      "keyword": None, "chapter_entry": None}
+
+
+def test_find_group_source_connpass_chapter():
+    source = find_group_source("soracomug-yamanashi")
+    assert source["type"] == "connpass"
+    assert source["subdomain"] == "soracomug-tokyo"
+    assert source["keyword"] == "山梨"
+
+
+def test_find_group_source_icalendar():
+    source = find_group_source("yamanashi-wordpress-meetup-ical")
+    assert source["type"] == "icalendar"
+    assert source["ical_url"] == \
+        "https://www.meetup.com/ja-JP/Yamanashi-WordPress-Meetup/events/ical/"
+
+
+@patch("app.service.split_connpass_scope", return_value=([], []))
+def test_find_group_source_archive(mock_split_connpass_scope):
+    assert find_group_source("yamanashi-web") == {"type": "archive"}
+
+
+def test_find_group_source_not_found():
+    assert find_group_source("no-such-group") is None
 
 
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,9 +32,7 @@ class MockConnpassEventRequest:
     def get_events_page(self, item_start, item_count, order="desc"):
         MockConnpassEventRequest.page_requests.append(
             {"item_start": item_start, "item_count": item_count, "order": order})
-        # _fixed_json() is in ascending (oldest-first) order; simulate
-        # connpass's native descending order the same way the real
-        # ConnpassEventRequest.get_events_page() treats "desc" as native.
+        # _fixed_json() is ascending; "desc" simulates connpass's native order.
         events = Event.from_json(self._fixed_json())
         if order == "desc":
             events = list(reversed(events))
@@ -650,11 +648,7 @@ def test_read_events_fromto_year_month_invalid_legacy_path_still_works():
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_plain_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_connpass_plain():
-    # config.yaml's real plain connpass subdomain, resolved from config
-    # alone -- no connpass groups API call needed. Plain (non-chapter)
-    # group with no keyword/uid filter takes the upstream-pagination fast
-    # path, so exactly one connpass request is made -- no background
-    # refetch, since that path bypasses get_events() entirely.
+    # Plain group, no keyword/uid: fast path, one request, no background refetch.
     response = client.get("/groups/jagyamanashi/events")
     assert response.status_code == 200
     events = response.json()
@@ -672,9 +666,7 @@ def test_read_group_events_connpass_plain():
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_plain_filtered_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_connpass_plain_with_uid_falls_back_to_full_fetch():
-    # A uid filter can't be applied correctly without the full result set,
-    # so this must fall back to get_events()'s crawl-everything path
-    # rather than the upstream-pagination fast path.
+    # uid filter forces the get_events() fallback, not the fast path.
     response = client.get("/groups/jagyamanashi/events", params={"uid": "UID 2"})
     assert response.status_code == 200
     events = response.json()
@@ -706,8 +698,7 @@ def test_read_group_events_default_pagination():
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_slice_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_pagination_slices_pages():
-    # Default order is "desc" (native/newest-first): reversed, page 2 of
-    # 1-per-page is the earlier event, UID 1.
+    # Default order "desc" (newest-first): page 2 of 1-per-page is UID 1.
     response = client.get("/groups/jagyamanashi/events",
                           params={"per_page": 1, "page": 2})
     assert response.status_code == 200
@@ -754,8 +745,7 @@ def test_read_group_events_pagination_rejects_invalid_params():
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_order_asc_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_ascending_order():
-    # order=asc reverses connpass's native descending order, so page 1 is
-    # the oldest event, UID 1.
+    # order=asc reverses the native descending order: page 1 is UID 1.
     response = client.get("/groups/jagyamanashi/events",
                           params={"per_page": 1, "order": "asc"})
     assert response.status_code == 200
@@ -795,10 +785,8 @@ def test_read_group_events_pagination_headers_kept_with_fields():
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_chapter_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_connpass_chapter():
-    # config.yaml defines chapter key "soracomug-yamanashi" carved out of the
-    # real subdomain "soracomug-tokyo" via title_keyword "山梨". A chapter's
-    # title match can only be applied after fetching everything, so this
-    # falls back to get_events()'s crawl-everything path.
+    # Chapter "soracomug-yamanashi" (subdomain "soracomug-tokyo", keyword
+    # "山梨") falls back to get_events()'s crawl, not the fast path.
     response = client.get("/groups/soracomug-yamanashi/events")
     assert response.status_code == 200
 
@@ -826,10 +814,8 @@ def test_read_group_events_icalendar():
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_archive_"))
 @patch("app.service.split_connpass_scope", return_value=([], []))
 def test_read_group_events_archive(mock_split_connpass_scope):
-    # config.yaml also has a real plain connpass subdomain "yamanashi-web";
-    # neutralize scope.connpass here to exercise the archive-only path
-    # (archive group identity has no config.yaml equivalent, so it's the
-    # one source find_group_source must actually query to confirm a match)
+    # "yamanashi-web" is also a real plain subdomain; neutralize
+    # scope.connpass to force the archive-only resolution path.
     response = client.get("/groups/yamanashi-web/events")
     assert response.status_code == 200
     events = response.json()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -952,6 +952,53 @@ def test_read_group_includes_archive_source(mock_get_groups_from_icalendar):
         "https://github.com/yuukis/yamanashi-event-archive"
 
 
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+def test_read_group_by_key(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/groups/Key")
+    assert response.status_code == 200
+    group = response.json()
+    assert isinstance(group, dict)
+    assert group["key"] == "Key"
+    assert group["title"] == "Title"
+
+
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+def test_read_group_by_key_not_found(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/groups/no-such-group")
+    assert response.status_code == 404
+
+
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+def test_read_group_by_key_with_fields(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/groups/Key", params={"fields": "key,title"})
+    assert response.status_code == 200
+    assert response.json() == {"key": "Key", "title": "Title"}
+
+
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+def test_read_group_by_key_returns_304_when_not_modified_since(
+        mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    baseline = client.get("/groups/Key")
+    last_modified = baseline.headers["Last-Modified"]
+
+    response = client.get("/groups/Key",
+                          headers={"If-Modified-Since": last_modified})
+    assert response.status_code == 304
+    assert response.content == b""
+
+
 def test_events_refresh_min_interval_falls_back_on_invalid_env_value(monkeypatch):
     import importlib
     import app.service as service_module

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,7 @@ from app.service import get_user_agent, get_groups_from_icalendar
 from app.service import request_events, request_groups, get_groups_from_archives
 from app.service import get_archive_urls, preload_archive_indexes
 from app.service import get_events, get_groups, normalize_event_params
+from app.service import find_group_by_key
 from app.service import fetch_events, fetch_groups
 from app.service import split_connpass_scope, partition_and_relabel_chapter_events
 from app.service import get_groups_from_connpass_chapters, merged_connpass_subdomains
@@ -19,8 +20,10 @@ client = TestClient(app)
 
 
 class MockConnpassEventRequest:
+    requests = []
+
     def __init__(self, **kwargs):
-        pass
+        MockConnpassEventRequest.requests.append(kwargs)
 
     def get_events(self):
         json = [
@@ -111,8 +114,10 @@ class MockConnpassGroupRequest:
 
 
 class MockICalEventRequest:
+    requests = []
+
     def __init__(self, **kwargs):
-        pass
+        MockICalEventRequest.requests.append(kwargs)
 
     def get_events(self):
         json = [
@@ -229,6 +234,18 @@ def mock_archive_index_request():
     MockArchiveIndexRequest.preloaded_urls = []
     with patch("app.service.ArchiveIndexRequest", MockArchiveIndexRequest):
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_connpass_event_request_calls():
+    MockConnpassEventRequest.requests = []
+    yield
+
+
+@pytest.fixture(autouse=True)
+def mock_ical_event_request_calls():
+    MockICalEventRequest.requests = []
+    yield
 
 
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
@@ -611,6 +628,97 @@ def test_read_events_fromto_year_month_legacy_path_still_works():
 def test_read_events_fromto_year_month_invalid_legacy_path_still_works():
     response = client.get("/events/from/2023/12/to/2022/11")
     assert response.status_code == 400
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_events_group_plain_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+def test_read_events_group_connpass_plain(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    # MockConnpassGroupRequest always reports a single plain group, key "Key"
+    response = client.get("/events/group/Key")
+    assert response.status_code == 200
+    events = response.json()
+    assert isinstance(events, list)
+
+    # background_tasks refetches once more after the initial response, so
+    # assert every recorded call was scoped the same way rather than count
+    assert len(MockConnpassEventRequest.requests) >= 1
+    for req in MockConnpassEventRequest.requests:
+        assert req["subdomain"] == ["Key"]
+        assert req["keyword"] is None
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_events_group_chapter_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+def test_read_events_group_connpass_chapter(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    # config.yaml defines chapter key "soracomug-yamanashi" carved out of the
+    # real subdomain "soracomug-tokyo" via title_keyword "山梨"
+    response = client.get("/events/group/soracomug-yamanashi")
+    assert response.status_code == 200
+
+    assert len(MockConnpassEventRequest.requests) >= 1
+    for req in MockConnpassEventRequest.requests:
+        assert req["subdomain"] == ["soracomug-tokyo"]
+        assert req["keyword"] == "山梨"
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_events_group_ical_"))
+@patch("app.service.IcalEventRequest", MockICalEventRequest)
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+def test_read_events_group_icalendar():
+    # config.yaml's real icalendar entry, resolved without mocking
+    # get_groups_from_icalendar since it does no network I/O itself
+    response = client.get("/events/group/yamanashi-wordpress-meetup-ical")
+    assert response.status_code == 200
+
+    assert len(MockICalEventRequest.requests) >= 1
+    for req in MockICalEventRequest.requests:
+        assert req["key"] == "yamanashi-wordpress-meetup-ical"
+        assert req["url"] == \
+            "https://www.meetup.com/ja-JP/Yamanashi-WordPress-Meetup/events/ical/"
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_events_group_archive_"))
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+def test_read_events_group_archive(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    # Archive indexes can't be queried per-group, so this must be filtered
+    # client-side against the mocked archive's fixed event list
+    response = client.get("/events/group/yamanashi-web")
+    assert response.status_code == 200
+    events = response.json()
+    assert len(events) == 1
+    assert events[0]["group_key"] == "yamanashi-web"
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_events_group_404_"))
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+def test_read_events_group_not_found(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/events/group/no-such-group")
+    assert response.status_code == 404
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_find_group_by_key_"))
+def test_find_group_by_key():
+    groups = [
+        Group.from_json({"key": "a", "title": "A"}),
+        Group.from_json({"key": "b", "title": "B"}),
+    ]
+    with patch("app.service.get_groups", return_value=(groups, None)):
+        assert find_group_by_key("b").key == "b"
+        assert find_group_by_key("no-such") is None
 
 
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)


### PR DESCRIPTION
## Summary
- Adds `GET /groups/{group_key}` — a single community group (404 if unknown).
- Adds `GET /groups/{group_key}/events` — a group's full event history, since this URL carries no date scope unlike the `/events/*` endpoints.
  - Paginated: `page`/`per_page` (default 50, max 200), with totals in `X-Total-Count`/`X-Page`/`X-Per-Page`/`X-Total-Pages` response headers (body stays a plain array, consistent with every other list endpoint).
  - `order=asc|desc` (default `desc`, connpass's native order).
  - For a plain (non-chapter) connpass group with no `keyword`/`uid` filter, paginates directly against connpass instead of crawling its whole history — one connpass call per page, chunked to connpass's own 100-item page boundaries so different `per_page` choices still share the same low-level cache entries instead of fragmenting it. Chapters and `keyword`/`uid` filters fall back to the existing full-fetch-then-filter path, since those can only be applied correctly once the complete result set is known.
- Both new endpoints are registered as MCP tools (`get_group`, `list_group_events`).
- Along the way, fixed a real bug this surfaced: connpass API v2's `order=2` sorts by `started_at` **descending**, not ascending as the existing code assumed — masked everywhere else by an explicit ascending re-sort, but not in the new upstream-pagination fast path.

## Test plan
- [x] `python -m pytest tests/` — 174 passed
- [x] Manually verified against the real connpass API (not just mocks): confirmed a single connpass call for a plain group's page, chunked+cached calls shared across different `per_page` values, correct `asc`/`desc` ordering, 404 for unknown groups, and 422 for invalid `page`/`per_page`/`order`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)