### PR TITLE
fix: expose pagination headers via Access-Control-Expose-Headers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-Total-Count", "X-Page", "X-Per-Page", "X-Total-Pages"],
 )
 
 # Imported for its side effect: registers all routes and mounts MCP onto

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -707,6 +707,19 @@ def test_read_group_events_default_pagination():
     assert response.headers["X-Total-Pages"] == "1"
 
 
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_cors_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+def test_read_group_events_exposes_pagination_headers_for_cors():
+    response = client.get("/groups/jagyamanashi/events",
+                          headers={"Origin": "https://example.com"})
+    assert response.status_code == 200
+
+    exposed = response.headers["access-control-expose-headers"]
+    exposed_headers = {h.strip() for h in exposed.split(",")}
+    assert exposed_headers == {
+        "X-Total-Count", "X-Page", "X-Per-Page", "X-Total-Pages"}
+
+
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_page_slice_"))
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 def test_read_group_events_pagination_slices_pages():


### PR DESCRIPTION
## Summary
- `CORSMiddleware` did not set `Access-Control-Expose-Headers`, so browsers hid custom pagination headers (`X-Total-Count`, `X-Page`, `X-Per-Page`, `X-Total-Pages`) from cross-origin `fetch`/`axios` calls even though `curl` could see them.
- Added `expose_headers=["X-Total-Count", "X-Page", "X-Per-Page", "X-Total-Pages"]` to the `CORSMiddleware` config in `app/main.py`, applying to all paginated endpoints (not just `/groups/{group_key}/events`).

## Test plan
- [x] Added `test_read_group_events_exposes_pagination_headers_for_cors` to verify `Access-Control-Expose-Headers` is present and lists all four pagination headers when a cross-origin `Origin` header is sent.
- [x] Full suite: `pytest -q` → 176 passed.

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)