### PR TITLE
同じキーのarchiveコミュニティをconnpass/icalendarへ統合

### DIFF
--- a/app/config.yaml
+++ b/app/config.yaml
@@ -39,7 +39,7 @@ scope:
       name: 'SORACOM UG 山梨'
 
   icalendar:
-    - key: 'yamanashi-wordpress-meetup-ical'
+    - key: 'yamanashi-wordpress-meetup'
       name: 'Yamanashi WordPress Meetup'
       image_url: null
       group_url: https://www.meetup.com/ja-JP/yamanashi-wordpress-meetup/

--- a/app/service.py
+++ b/app/service.py
@@ -6,6 +6,7 @@ from .providers.archive import ArchiveIndexRequest, ArchiveException
 from .models import Event, Group
 from .cache import EventRequestCache
 from .keywords import KeywordExtractor
+import dataclasses
 import os
 from datetime import datetime, timezone
 import yaml
@@ -203,36 +204,52 @@ def request_events(params, cache_ttl: int = None,
 
 
 def find_group_source(group_key) -> Optional[dict]:
-    """Resolve group_key to its configured source using only config.yaml;
-    only scope.archives needs an actual fetch (its own index), since
-    archive group identity isn't declared in config.yaml. Returns None if
-    group_key isn't configured (prefecture-only discoveries don't count)."""
+    """Resolve group_key to its configured source. A connpass/icalendar
+    primary source and an archive can both back the same group_key (a
+    community whose recent events live on connpass/icalendar but whose
+    older events were migrated into an archive index under the same key);
+    when that happens, the primary source's dict gets "also_archive": True
+    so callers know to merge in archive events too. Returns None if
+    group_key isn't configured anywhere (prefecture-only discoveries don't
+    count)."""
     global cache
 
     plain_subdomains, chapters = split_connpass_scope(config)
 
+    primary = None
     chapter_entry = next((c for c in chapters if c["key"] == group_key), None)
     if chapter_entry is not None:
-        return {"type": "connpass", "subdomain": chapter_entry["subdomain"],
-                "keyword": chapter_entry["title_keyword"],
-                "chapter_entry": chapter_entry}
+        primary = {"type": "connpass", "subdomain": chapter_entry["subdomain"],
+                   "keyword": chapter_entry["title_keyword"],
+                   "chapter_entry": chapter_entry}
 
-    if group_key in plain_subdomains:
-        return {"type": "connpass", "subdomain": group_key, "keyword": None,
-                "chapter_entry": None}
+    elif group_key in plain_subdomains:
+        primary = {"type": "connpass", "subdomain": group_key, "keyword": None,
+                   "chapter_entry": None}
 
-    if "scope" in config and "icalendar" in config["scope"]:
+    elif "scope" in config and "icalendar" in config["scope"]:
         for entry in config["scope"]["icalendar"]:
             if entry["key"] == group_key:
-                return {"type": "icalendar", "ical_url": entry["ical_url"],
-                        "name": entry["name"],
-                        "group_url": entry.get("group_url")}
+                primary = {"type": "icalendar", "ical_url": entry["ical_url"],
+                           "name": entry["name"],
+                           "group_url": entry.get("group_url")}
+                break
 
+    has_archive_group = False
     if "scope" in config and "archives" in config["scope"]:
         for url in get_archive_urls(config):
             r = ArchiveIndexRequest(url=url, cache=cache)
             if any(g.key == group_key for g in r.get_groups()):
-                return {"type": "archive"}
+                has_archive_group = True
+                break
+
+    if primary is not None:
+        if has_archive_group:
+            primary["also_archive"] = True
+        return primary
+
+    if has_archive_group:
+        return {"type": "archive"}
 
     return None
 
@@ -267,7 +284,10 @@ def request_events_for_group(source: dict, group_key, ym, ymd, cache_ttl: int,
         events += r.get_events()
         last_modified = max(last_modified, r.get_last_modified())
 
-    elif source["type"] == "archive":
+    # Not "elif": a connpass/icalendar primary source and an archive can
+    # both back the same group_key (see find_group_source()'s
+    # "also_archive"), in which case both contribute events.
+    if source["type"] == "archive" or source.get("also_archive"):
         # Archive indexes have no per-group query -- filter client-side.
         for url in get_archive_urls(config):
             r = ArchiveIndexRequest(url=url, ym=ym, ymd=ymd, cache=cache)
@@ -303,6 +323,7 @@ def get_group_events_page(group_key, keyword, uid, page: int, per_page: int,
     can_paginate_upstream = (
         source["type"] == "connpass"
         and source["chapter_entry"] is None
+        and not source.get("also_archive")
         and keyword is None
         and uid is None
     )
@@ -417,7 +438,37 @@ def request_groups(params) -> Tuple[List[Group], datetime]:
     except ArchiveException as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
 
+    groups = merge_duplicate_groups(groups)
+
     return groups, last_modified
+
+
+def merge_duplicate_groups(groups: List[Group]) -> List[Group]:
+    """Fold multiple Group entries sharing the same key (e.g. a connpass
+    group and an archive whose community was migrated under the same key)
+    into one. The first entry with a given key is kept as the base; later
+    duplicates are dropped, but any field left unset (None) on the base is
+    backfilled from them -- this is how an archive-only field like
+    archive_source/archive_url reaches a group whose primary entry comes
+    from connpass/icalendar."""
+    merged_by_key = {}
+    order = []
+    for g in groups:
+        if g.key not in merged_by_key:
+            merged_by_key[g.key] = g
+            order.append(g.key)
+            continue
+
+        base = merged_by_key[g.key]
+        for field in dataclasses.fields(Group):
+            if field.name in ("id", "key"):
+                continue
+            if getattr(base, field.name) is None:
+                value = getattr(g, field.name)
+                if value is not None:
+                    setattr(base, field.name, value)
+
+    return [merged_by_key[key] for key in order]
 
 
 def get_user_agent(config):

--- a/app/service.py
+++ b/app/service.py
@@ -19,6 +19,10 @@ config_file = os.path.join(dirname, "config.yaml")
 cache = EventRequestCache()
 keyword_extractor = KeywordExtractor()
 
+# Lazily computed set of every community key across configured archives,
+# memoized for the life of the process (see get_archive_group_keys()).
+_archive_group_keys = None
+
 with open(config_file, "r", encoding="utf-8") as yml:
     config = yaml.safe_load(yml)
 
@@ -203,6 +207,29 @@ def request_events(params, cache_ttl: int = None,
     return events, last_modified
 
 
+def get_archive_group_keys() -> set:
+    """All community keys across every configured archive index, memoized
+    for the life of the process. Safe to memoize indefinitely: once an
+    archive index is successfully fetched, ArchiveIndexRequest caches its
+    JSON without expiration for the rest of the process too (see
+    docs/archive-index.md), so this set can't go stale mid-process either.
+    A fetch failure is not memoized, so a later call retries instead of
+    permanently assuming "no archive communities"."""
+    global _archive_group_keys, cache
+
+    if _archive_group_keys is not None:
+        return _archive_group_keys
+
+    keys = set()
+    if "scope" in config and "archives" in config["scope"]:
+        for url in get_archive_urls(config):
+            r = ArchiveIndexRequest(url=url, cache=cache)
+            keys |= {g.key for g in r.get_groups()}
+
+    _archive_group_keys = keys
+    return _archive_group_keys
+
+
 def find_group_source(group_key) -> Optional[dict]:
     """Resolve group_key to its configured source. A connpass/icalendar
     primary source and an archive can both back the same group_key (a
@@ -212,8 +239,6 @@ def find_group_source(group_key) -> Optional[dict]:
     so callers know to merge in archive events too. Returns None if
     group_key isn't configured anywhere (prefecture-only discoveries don't
     count)."""
-    global cache
-
     plain_subdomains, chapters = split_connpass_scope(config)
 
     primary = None
@@ -235,13 +260,7 @@ def find_group_source(group_key) -> Optional[dict]:
                            "group_url": entry.get("group_url")}
                 break
 
-    has_archive_group = False
-    if "scope" in config and "archives" in config["scope"]:
-        for url in get_archive_urls(config):
-            r = ArchiveIndexRequest(url=url, cache=cache)
-            if any(g.key == group_key for g in r.get_groups()):
-                has_archive_group = True
-                break
+    has_archive_group = group_key in get_archive_group_keys()
 
     if primary is not None:
         if has_archive_group:

--- a/app/service.py
+++ b/app/service.py
@@ -19,8 +19,8 @@ config_file = os.path.join(dirname, "config.yaml")
 cache = EventRequestCache()
 keyword_extractor = KeywordExtractor()
 
-# Lazily computed set of every community key across configured archives,
-# memoized for the life of the process (see get_archive_group_keys()).
+# Lazily computed frozenset of every community key across configured
+# archives, memoized for the life of the process (see get_archive_group_keys()).
 _archive_group_keys = None
 
 with open(config_file, "r", encoding="utf-8") as yml:
@@ -207,14 +207,17 @@ def request_events(params, cache_ttl: int = None,
     return events, last_modified
 
 
-def get_archive_group_keys() -> set:
+def get_archive_group_keys() -> frozenset:
     """All community keys across every configured archive index, memoized
     for the life of the process. Safe to memoize indefinitely: once an
     archive index is successfully fetched, ArchiveIndexRequest caches its
     JSON without expiration for the rest of the process too (see
     docs/archive-index.md), so this set can't go stale mid-process either.
     A fetch failure is not memoized, so a later call retries instead of
-    permanently assuming "no archive communities"."""
+    permanently assuming "no archive communities". Returns a frozenset,
+    not a set, since the same object is reused for every call for the
+    rest of the process -- a mutable set would let one caller's mistaken
+    .add()/.clear() silently corrupt it for everyone else."""
     global _archive_group_keys, cache
 
     if _archive_group_keys is not None:
@@ -226,7 +229,7 @@ def get_archive_group_keys() -> set:
             r = ArchiveIndexRequest(url=url, cache=cache)
             keys |= {g.key for g in r.get_groups()}
 
-    _archive_group_keys = keys
+    _archive_group_keys = frozenset(keys)
     return _archive_group_keys
 
 

--- a/app/service.py
+++ b/app/service.py
@@ -19,9 +19,7 @@ config_file = os.path.join(dirname, "config.yaml")
 cache = EventRequestCache()
 keyword_extractor = KeywordExtractor()
 
-# Lazily computed frozenset of every community key across configured
-# archives, memoized for the life of the process (see get_archive_group_keys()).
-_archive_group_keys = None
+_archive_group_keys = None  # see get_archive_group_keys()
 
 with open(config_file, "r", encoding="utf-8") as yml:
     config = yaml.safe_load(yml)
@@ -208,16 +206,8 @@ def request_events(params, cache_ttl: int = None,
 
 
 def get_archive_group_keys() -> frozenset:
-    """All community keys across every configured archive index, memoized
-    for the life of the process. Safe to memoize indefinitely: once an
-    archive index is successfully fetched, ArchiveIndexRequest caches its
-    JSON without expiration for the rest of the process too (see
-    docs/archive-index.md), so this set can't go stale mid-process either.
-    A fetch failure is not memoized, so a later call retries instead of
-    permanently assuming "no archive communities". Returns a frozenset,
-    not a set, since the same object is reused for every call for the
-    rest of the process -- a mutable set would let one caller's mistaken
-    .add()/.clear() silently corrupt it for everyone else."""
+    """Community keys across all archives, memoized for the process (a
+    frozenset so callers can't mutate the shared cache)."""
     global _archive_group_keys, cache
 
     if _archive_group_keys is not None:
@@ -234,14 +224,8 @@ def get_archive_group_keys() -> frozenset:
 
 
 def find_group_source(group_key) -> Optional[dict]:
-    """Resolve group_key to its configured source. A connpass/icalendar
-    primary source and an archive can both back the same group_key (a
-    community whose recent events live on connpass/icalendar but whose
-    older events were migrated into an archive index under the same key);
-    when that happens, the primary source's dict gets "also_archive": True
-    so callers know to merge in archive events too. Returns None if
-    group_key isn't configured anywhere (prefecture-only discoveries don't
-    count)."""
+    """Resolve group_key to its source; flags "also_archive" when an
+    archive also has a community under the same key."""
     plain_subdomains, chapters = split_connpass_scope(config)
 
     primary = None
@@ -306,9 +290,7 @@ def request_events_for_group(source: dict, group_key, ym, ymd, cache_ttl: int,
         events += r.get_events()
         last_modified = max(last_modified, r.get_last_modified())
 
-    # Not "elif": a connpass/icalendar primary source and an archive can
-    # both back the same group_key (see find_group_source()'s
-    # "also_archive"), in which case both contribute events.
+    # Not "elif": a primary source and an archive can both contribute events.
     if source["type"] == "archive" or source.get("also_archive"):
         # Archive indexes have no per-group query -- filter client-side.
         for url in get_archive_urls(config):
@@ -466,13 +448,8 @@ def request_groups(params) -> Tuple[List[Group], datetime]:
 
 
 def merge_duplicate_groups(groups: List[Group]) -> List[Group]:
-    """Fold multiple Group entries sharing the same key (e.g. a connpass
-    group and an archive whose community was migrated under the same key)
-    into one. The first entry with a given key is kept as the base; later
-    duplicates are dropped, but any field left unset (None) on the base is
-    backfilled from them -- this is how an archive-only field like
-    archive_source/archive_url reaches a group whose primary entry comes
-    from connpass/icalendar."""
+    """Fold Group entries sharing a key into one, backfilling only the
+    base's null fields from later duplicates."""
     merged_by_key = {}
     order = []
     for g in groups:

--- a/docs/archive-index.md
+++ b/docs/archive-index.md
@@ -30,6 +30,25 @@ scope:
         - https://example.github.io/another-tech-event-archive/index.json
 ```
 
+## Merging with connpass/icalendar communities
+
+A community's identity is its `key`. If a `communities[].key` (and the
+matching `events[].group_key`) in the archive index is set to the *same*
+key as an existing `scope.connpass` or `scope.icalendar` entry, the API
+treats them as one community: `/groups` returns a single merged entry
+(archive-only fields such as `archive_source`/`archive_url` are filled in
+on top of the connpass/icalendar group), and `/groups/{key}/events` and
+`/summary/events` include both the archive's historical events and the
+live connpass/icalendar events under that one key.
+
+This is how a community that has since moved from a standalone archived
+group to an active connpass/icalendar group (or vice versa) should be
+modeled -- give the archive entry the same `key` as the live one, rather
+than a different key, so its historical events count as that community's
+events instead of a separate one. Give `events[].group_name`/`group_url`
+in the archive index the community's current display name/URL too, since
+the API does not rewrite them.
+
 ## JSON Format
 
 The top-level `events` array is converted to `Event`. The top-level

--- a/docs/archive-index.md
+++ b/docs/archive-index.md
@@ -32,22 +32,9 @@ scope:
 
 ## Merging with connpass/icalendar communities
 
-A community's identity is its `key`. If a `communities[].key` (and the
-matching `events[].group_key`) in the archive index is set to the *same*
-key as an existing `scope.connpass` or `scope.icalendar` entry, the API
-treats them as one community: `/groups` returns a single merged entry
-(archive-only fields such as `archive_source`/`archive_url` are filled in
-on top of the connpass/icalendar group), and `/groups/{key}/events` and
-`/summary/events` include both the archive's historical events and the
-live connpass/icalendar events under that one key.
-
-This is how a community that has since moved from a standalone archived
-group to an active connpass/icalendar group (or vice versa) should be
-modeled -- give the archive entry the same `key` as the live one, rather
-than a different key, so its historical events count as that community's
-events instead of a separate one. Give `events[].group_name`/`group_url`
-in the archive index the community's current display name/URL too, since
-the API does not rewrite them.
+Giving `communities[].key` (and matching `events[].group_key`) the same
+value as an existing `scope.connpass`/`scope.icalendar` entry merges them
+into one community.
 
 ## JSON Format
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,11 +7,12 @@ from app.service import get_user_agent, get_groups_from_icalendar
 from app.service import request_events, request_groups, get_groups_from_archives
 from app.service import get_archive_urls, preload_archive_indexes
 from app.service import get_events, get_groups, normalize_event_params
-from app.service import find_group_source
+from app.service import find_group_source, get_archive_group_keys
 from app.service import fetch_events, fetch_groups
 from app.service import split_connpass_scope, partition_and_relabel_chapter_events
 from app.service import get_groups_from_connpass_chapters, merged_connpass_subdomains
 from app.service import merge_duplicate_groups
+from app import service
 from app.cache import EventRequestCache
 from app.providers.archive import ArchiveException
 from app.models import Event, Group
@@ -324,8 +325,13 @@ class MockFailingPreloadArchiveIndexRequest:
 def mock_archive_index_request():
     MockArchiveIndexRequest.requested_urls = []
     MockArchiveIndexRequest.preloaded_urls = []
+    # get_archive_group_keys() memoizes across calls for the life of the
+    # process; reset it per test so one test's archive mock/config can't
+    # leak into another's.
+    service._archive_group_keys = None
     with patch("app.service.ArchiveIndexRequest", MockArchiveIndexRequest):
         yield
+    service._archive_group_keys = None
 
 
 @pytest.fixture(autouse=True)
@@ -970,6 +976,18 @@ def test_find_group_source_also_archive_when_archive_key_matches_primary():
     assert source["type"] == "connpass"
     assert source["subdomain"] == "jagyamanashi"
     assert source["also_archive"] is True
+
+
+def test_get_archive_group_keys_is_memoized():
+    first = get_archive_group_keys()
+    assert first == {"yamanashi-web"}
+
+    requests_before = len(MockArchiveIndexRequest.requested_urls)
+    second = get_archive_group_keys()
+
+    assert second is first
+    # No new ArchiveIndexRequest was constructed for the memoized call.
+    assert len(MockArchiveIndexRequest.requested_urls) == requests_before
 
 
 @patch("app.service.cache", EventRequestCache(prefix="test_group_events_archive_merge_"))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -981,6 +981,9 @@ def test_find_group_source_also_archive_when_archive_key_matches_primary():
 def test_get_archive_group_keys_is_memoized():
     first = get_archive_group_keys()
     assert first == {"yamanashi-web"}
+    # Immutable, so a caller can't accidentally corrupt the memoized value
+    # for the rest of the process (no .add()/.clear() exist on it).
+    assert isinstance(first, frozenset)
 
     requests_before = len(MockArchiveIndexRequest.requested_urls)
     second = get_archive_group_keys()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -905,12 +905,12 @@ def test_read_group_events_connpass_chapter():
 @patch("app.service.IcalEventRequest", MockICalEventRequest)
 def test_read_group_events_icalendar():
     # config.yaml's real icalendar entry, resolved from config alone
-    response = client.get("/groups/yamanashi-wordpress-meetup-ical/events")
+    response = client.get("/groups/yamanashi-wordpress-meetup/events")
     assert response.status_code == 200
 
     assert len(MockICalEventRequest.requests) >= 1
     for req in MockICalEventRequest.requests:
-        assert req["key"] == "yamanashi-wordpress-meetup-ical"
+        assert req["key"] == "yamanashi-wordpress-meetup"
         assert req["url"] == \
             "https://www.meetup.com/ja-JP/Yamanashi-WordPress-Meetup/events/ical/"
 
@@ -947,7 +947,7 @@ def test_find_group_source_connpass_chapter():
 
 
 def test_find_group_source_icalendar():
-    source = find_group_source("yamanashi-wordpress-meetup-ical")
+    source = find_group_source("yamanashi-wordpress-meetup")
     assert source["type"] == "icalendar"
     assert source["ical_url"] == \
         "https://www.meetup.com/ja-JP/Yamanashi-WordPress-Meetup/events/ical/"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,6 +11,7 @@ from app.service import find_group_source
 from app.service import fetch_events, fetch_groups
 from app.service import split_connpass_scope, partition_and_relabel_chapter_events
 from app.service import get_groups_from_connpass_chapters, merged_connpass_subdomains
+from app.service import merge_duplicate_groups
 from app.cache import EventRequestCache
 from app.providers.archive import ArchiveException
 from app.models import Event, Group
@@ -232,6 +233,83 @@ class MockArchiveIndexRequest:
 
     def preload(self):
         MockArchiveIndexRequest.preloaded_urls.append(self.url)
+
+
+class MockArchiveIndexRequestJagyamanashi(MockArchiveIndexRequest):
+    """An archive whose community was migrated under the same key as the
+    real config.yaml connpass entry "jagyamanashi", for testing the
+    connpass+archive merge behavior."""
+
+    def get_events(self):
+        json = [
+            {
+                "uid": "jagyamanashi-2015-01-01-001@yamanashi-event-archive",
+                "event_id": None,
+                "title": "日本Androidの会 山梨支部 第1回",
+                "catch": None,
+                "hash_tag": None,
+                "event_url": "https://example.com/archive/jagyamanashi/2015-01-01-001",
+                "started_at": "2015-01-01T14:00:00+09:00",
+                "ended_at": "2015-01-01T17:00:00+09:00",
+                "updated_at": "2026-06-30T00:00:00+09:00",
+                "open_status": "close",
+                "limit": None,
+                "accepted": None,
+                "waiting": None,
+                "owner_name": None,
+                "place": None,
+                "address": None,
+                "group_key": "jagyamanashi",
+                "group_name": "日本Androidの会 山梨支部",
+                "group_url": "https://jagyamanashi.connpass.com/",
+                "description": None,
+                "lat": None,
+                "lon": None
+            }
+        ]
+        return Event.from_json(json)
+
+    def get_groups(self):
+        json = [
+            {
+                "key": "jagyamanashi",
+                "title": "日本Androidの会 山梨支部（アーカイブ）",
+                "sub_title": None,
+                "url": "https://example.com/jagyamanashi",
+                "description": None,
+                "owner_text": None,
+                "image_url": None,
+                "website_url": None,
+                "x_username": None,
+                "facebook_url": None,
+                "member_users_count": None,
+                "ical_url": None,
+                "archive_source": "yamanashi-event-archive",
+                "archive_url": "https://github.com/yuukis/yamanashi-event-archive"
+            }
+        ]
+        return Group.from_json(json)
+
+
+class MockConnpassGroupRequestJagyamanashi(MockConnpassGroupRequest):
+    def get_groups(self):
+        json = [
+            {
+                "id": 1,
+                "key": "jagyamanashi",
+                "title": "日本Androidの会 山梨支部",
+                "sub_title": None,
+                "url": "https://jagyamanashi.connpass.com/",
+                "description": None,
+                "owner_text": None,
+                "image_url": None,
+                "website_url": None,
+                "x_username": None,
+                "facebook_url": None,
+                "member_users_count": 50
+            }
+        ]
+        return Group.from_json(json)
 
 
 class MockFailingPreloadArchiveIndexRequest:
@@ -883,6 +961,38 @@ def test_find_group_source_not_found():
     assert find_group_source("no-such-group") is None
 
 
+@patch("app.service.ArchiveIndexRequest", MockArchiveIndexRequestJagyamanashi)
+def test_find_group_source_also_archive_when_archive_key_matches_primary():
+    # "jagyamanashi" is a real plain connpass entry in config.yaml; when an
+    # archive also has a community under that same key, the primary source
+    # is flagged so callers know to merge in archive events too.
+    source = find_group_source("jagyamanashi")
+    assert source["type"] == "connpass"
+    assert source["subdomain"] == "jagyamanashi"
+    assert source["also_archive"] is True
+
+
+@patch("app.service.cache", EventRequestCache(prefix="test_group_events_archive_merge_"))
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.service.ArchiveIndexRequest", MockArchiveIndexRequestJagyamanashi)
+def test_read_group_events_merges_archive_when_key_matches_connpass():
+    response = client.get("/groups/jagyamanashi/events")
+    assert response.status_code == 200
+    events = response.json()
+
+    # 2 connpass events + 1 archive event sharing the "jagyamanashi" key
+    assert len(events) == 3
+    assert response.headers["X-Total-Count"] == "3"
+    assert any(ev["uid"] == "jagyamanashi-2015-01-01-001@yamanashi-event-archive"
+              for ev in events)
+    assert all(ev["group_key"] == "jagyamanashi" for ev in events
+              if ev["uid"].startswith("jagyamanashi-"))
+
+    # also_archive disables the connpass upstream-pagination fast path,
+    # since only a local merge+sort can produce a correct combined total.
+    assert MockConnpassEventRequest.page_requests == []
+
+
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.service.IcalEventRequest", MockICalEventRequest)
 @patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
@@ -1107,6 +1217,40 @@ def test_read_group_includes_archive_source(mock_get_groups_from_icalendar):
     ][0]
     assert archive_group["archive_source"] == "yamanashi-event-archive"
     assert archive_group["archive_url"] == \
+        "https://github.com/yuukis/yamanashi-event-archive"
+
+
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequestJagyamanashi)
+@patch("app.service.get_groups_from_icalendar")
+@patch("app.service.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "connpass": [{"subdomain": "jagyamanashi"}],
+        "archives": [
+            {
+                "url": "https://example.com/archive/index.json"
+            }
+        ]
+    }
+})
+@patch("app.service.ArchiveIndexRequest", MockArchiveIndexRequestJagyamanashi)
+@patch("app.service.cache", EventRequestCache(prefix="test_groups_merge_archive_"))
+def test_read_groups_merges_duplicate_key_from_archive(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/groups")
+
+    assert response.status_code == 200
+    matching = [g for g in response.json() if g["key"] == "jagyamanashi"]
+    assert len(matching) == 1
+
+    merged = matching[0]
+    # connpass's own (non-null) fields win over the archive's duplicate entry...
+    assert merged["title"] == "日本Androidの会 山梨支部"
+    assert merged["member_users_count"] == 50
+    # ...but archive-only fields (null on the connpass entry) get backfilled.
+    assert merged["archive_source"] == "yamanashi-event-archive"
+    assert merged["archive_url"] == \
         "https://github.com/yuukis/yamanashi-event-archive"
 
 
@@ -1499,6 +1643,44 @@ def test_merged_connpass_subdomains_dedupes_and_preserves_order():
         ["jagyamanashi", "soracomug-tokyo"], chapters)
 
     assert merged == ["jagyamanashi", "soracomug-tokyo"]
+
+
+def _make_group(key, **overrides):
+    fields = {
+        "id": None, "key": key, "title": None, "sub_title": None, "url": None,
+        "description": None, "owner_text": None, "image_url": None,
+        "website_url": None, "x_username": None, "facebook_url": None,
+        "member_users_count": None, "ical_url": None,
+        "archive_source": None, "archive_url": None,
+    }
+    fields.update(overrides)
+    return Group(**fields)
+
+
+def test_merge_duplicate_groups_backfills_null_fields_without_overwriting():
+    base = _make_group("k", id=1, title="Title A", url="https://a",
+                       member_users_count=10)
+    dup = _make_group("k", id=2, title="Title B", sub_title="Sub B",
+                      description="Desc B", archive_source="src",
+                      archive_url="https://archive")
+    other = _make_group("other", title="Other")
+
+    merged = merge_duplicate_groups([base, dup, other])
+
+    assert [g.key for g in merged] == ["k", "other"]
+    result = merged[0]
+    assert result.id == 1  # base's own id/key kept, not overwritten
+    assert result.title == "Title A"  # not overwritten since already set
+    assert result.url == "https://a"  # not overwritten
+    assert result.sub_title == "Sub B"  # backfilled from the duplicate
+    assert result.description == "Desc B"  # backfilled from the duplicate
+    assert result.archive_source == "src"  # backfilled from the duplicate
+    assert result.archive_url == "https://archive"  # backfilled from the duplicate
+
+
+def test_merge_duplicate_groups_is_noop_for_unique_keys():
+    groups = [_make_group("a", title="A"), _make_group("b", title="B")]
+    assert merge_duplicate_groups(groups) == groups
 
 
 def test_partition_and_relabel_chapter_events_filters_by_title_only():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -237,9 +237,7 @@ class MockArchiveIndexRequest:
 
 
 class MockArchiveIndexRequestJagyamanashi(MockArchiveIndexRequest):
-    """An archive whose community was migrated under the same key as the
-    real config.yaml connpass entry "jagyamanashi", for testing the
-    connpass+archive merge behavior."""
+    """An archive community sharing its key with the real "jagyamanashi" connpass entry."""
 
     def get_events(self):
         json = [
@@ -325,10 +323,7 @@ class MockFailingPreloadArchiveIndexRequest:
 def mock_archive_index_request():
     MockArchiveIndexRequest.requested_urls = []
     MockArchiveIndexRequest.preloaded_urls = []
-    # get_archive_group_keys() memoizes across calls for the life of the
-    # process; reset it per test so one test's archive mock/config can't
-    # leak into another's.
-    service._archive_group_keys = None
+    service._archive_group_keys = None  # reset the process-lifetime memoization
     with patch("app.service.ArchiveIndexRequest", MockArchiveIndexRequest):
         yield
     service._archive_group_keys = None
@@ -969,9 +964,7 @@ def test_find_group_source_not_found():
 
 @patch("app.service.ArchiveIndexRequest", MockArchiveIndexRequestJagyamanashi)
 def test_find_group_source_also_archive_when_archive_key_matches_primary():
-    # "jagyamanashi" is a real plain connpass entry in config.yaml; when an
-    # archive also has a community under that same key, the primary source
-    # is flagged so callers know to merge in archive events too.
+    # "jagyamanashi" is a real plain connpass entry in config.yaml.
     source = find_group_source("jagyamanashi")
     assert source["type"] == "connpass"
     assert source["subdomain"] == "jagyamanashi"
@@ -981,8 +974,6 @@ def test_find_group_source_also_archive_when_archive_key_matches_primary():
 def test_get_archive_group_keys_is_memoized():
     first = get_archive_group_keys()
     assert first == {"yamanashi-web"}
-    # Immutable, so a caller can't accidentally corrupt the memoized value
-    # for the rest of the process (no .add()/.clear() exist on it).
     assert isinstance(first, frozenset)
 
     requests_before = len(MockArchiveIndexRequest.requested_urls)
@@ -1009,8 +1000,7 @@ def test_read_group_events_merges_archive_when_key_matches_connpass():
     assert all(ev["group_key"] == "jagyamanashi" for ev in events
               if ev["uid"].startswith("jagyamanashi-"))
 
-    # also_archive disables the connpass upstream-pagination fast path,
-    # since only a local merge+sort can produce a correct combined total.
+    # fast path (upstream pagination) must be disabled when merging archives
     assert MockConnpassEventRequest.page_requests == []
 
 
@@ -1690,13 +1680,15 @@ def test_merge_duplicate_groups_backfills_null_fields_without_overwriting():
 
     assert [g.key for g in merged] == ["k", "other"]
     result = merged[0]
-    assert result.id == 1  # base's own id/key kept, not overwritten
-    assert result.title == "Title A"  # not overwritten since already set
-    assert result.url == "https://a"  # not overwritten
-    assert result.sub_title == "Sub B"  # backfilled from the duplicate
-    assert result.description == "Desc B"  # backfilled from the duplicate
-    assert result.archive_source == "src"  # backfilled from the duplicate
-    assert result.archive_url == "https://archive"  # backfilled from the duplicate
+    # base's own already-set fields are kept, not overwritten
+    assert result.id == 1
+    assert result.title == "Title A"
+    assert result.url == "https://a"
+    # base's null fields are backfilled from the duplicate
+    assert result.sub_title == "Sub B"
+    assert result.description == "Desc B"
+    assert result.archive_source == "src"
+    assert result.archive_url == "https://archive"
 
 
 def test_merge_duplicate_groups_is_noop_for_unique_keys():


### PR DESCRIPTION
## Summary
- connpass/icalendar側のコミュニティと同じキーを持つarchiveコミュニティが存在する場合に、これまで無視されていたarchive側のイベント・グループ情報を統合するよう修正
- `find_group_source()` が一次ソース（connpass/icalendar）にマッチした時点で早期returnしており、同キーのarchiveデータを一切見ていなかったのが原因
- `/groups`: 同キーのGroupを1件にマージ（connpass/icalendar側の値を優先し、`null`のフィールドのみarchive側で補完）
- `/groups/{group_key}/events`: connpass/icalendarの現行イベントとarchiveの過去イベントを合算して返す（`also_archive`な場合はupstream paginationのfast pathを無効化し、ローカルでマージ・ソート）
- `/events`・`/summary/events` は元々`group_key`でバケット化しているだけなので、archive側のキーが正規キーと一致してさえいれば無修正で正しく合算される

これにより、例えば `jagyamanashi`（connpass）と同じキーで登録されたarchiveコミュニティが1つのコミュニティとして扱われるようになる。実際に既存の重複コミュニティ（`jagyamanashi`/`jagyamanashi-old`、`yamanashi-wordpress-meetup-ical`/`yamanashi-wordpress-meetup`）を統合するには、別リポジトリ `yamanashi-event-archive` の `index.json` 側で該当コミュニティ・イベントのキーを正規キーに書き換える必要がある（本PRのスコープ外）。

## Test plan
- [x] `python3 -m pytest` で既存181件 + 新規6件、計187件が通過
- [x] 既存テストは無修正のまま通過（`also_archive`はキーが実際に一致した場合のみ発火するため）