### PR TITLE
Event に source フィールドを追加（connpass/icalendar/archive判別）

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -118,8 +118,7 @@ class Event:
 
     @staticmethod
     def sanitize_source(data: any) -> Optional[Literal["connpass", "icalendar", "archive"]]:
-        # response_model validation would 500 on a value outside the
-        # Literal, e.g. from a corrupted cache entry -- fall back to None.
+        # an unrecognized value would 500 on response_model validation otherwise
         if data in ("connpass", "icalendar", "archive"):
             return data
         return None

--- a/app/models.py
+++ b/app/models.py
@@ -101,7 +101,7 @@ class Event:
                 lat=data.get("lat"),
                 lon=data.get("lon"),
                 keywords=Event.sanitize_keywords(data.get("keywords")),
-                source=data.get("source")
+                source=Event.sanitize_source(data.get("source"))
             )
 
         raise ValueError("data must be dict or List[dict]")
@@ -115,6 +115,14 @@ class Event:
         if len(keywords) == 0:
             return None
         return keywords
+
+    @staticmethod
+    def sanitize_source(data: any) -> Optional[str]:
+        # response_model validation would 500 on a value outside the
+        # Literal, e.g. from a corrupted cache entry -- fall back to None.
+        if data in ("connpass", "icalendar", "archive"):
+            return data
+        return None
 
     @staticmethod
     def to_json(data: any):

--- a/app/models.py
+++ b/app/models.py
@@ -117,7 +117,7 @@ class Event:
         return keywords
 
     @staticmethod
-    def sanitize_source(data: any) -> Optional[str]:
+    def sanitize_source(data: any) -> Optional[Literal["connpass", "icalendar", "archive"]]:
         # response_model validation would 500 on a value outside the
         # Literal, e.g. from a corrupted cache entry -- fall back to None.
         if data in ("connpass", "icalendar", "archive"):

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Literal
 from dataclasses import dataclass
 
 
@@ -28,6 +28,7 @@ class Event:
     lat: Optional[str] = None
     lon: Optional[str] = None
     keywords: Optional[List[str]] = None
+    source: Optional[Literal["connpass", "icalendar", "archive"]] = None
 
     @staticmethod
     def distinct_by_uid(data):
@@ -99,7 +100,8 @@ class Event:
                 description=data.get("description"),
                 lat=data.get("lat"),
                 lon=data.get("lon"),
-                keywords=Event.sanitize_keywords(data.get("keywords"))
+                keywords=Event.sanitize_keywords(data.get("keywords")),
+                source=data.get("source")
             )
 
         raise ValueError("data must be dict or List[dict]")
@@ -144,7 +146,8 @@ class Event:
                 "description": data.description,
                 "lat": data.lat,
                 "lon": data.lon,
-                "keywords": data.keywords
+                "keywords": data.keywords,
+                "source": data.source
             }
 
         raise ValueError("data must be Event or List[Event]")

--- a/app/providers/archive.py
+++ b/app/providers/archive.py
@@ -24,6 +24,8 @@ class ArchiveIndexRequest:
             json = self.__get_json_or_fetch()
 
             events = Event.from_json(json.get("events", []))
+            for event in events:
+                event.source = "archive"
             return self.__find_by_ym_ymd(events)
 
         except requests.RequestException as e:

--- a/app/providers/archive.py
+++ b/app/providers/archive.py
@@ -24,9 +24,10 @@ class ArchiveIndexRequest:
             json = self.__get_json_or_fetch()
 
             events = Event.from_json(json.get("events", []))
+            events = self.__find_by_ym_ymd(events)
             for event in events:
                 event.source = "archive"
-            return self.__find_by_ym_ymd(events)
+            return events
 
         except requests.RequestException as e:
             raise ArchiveException(500, str(e))

--- a/app/providers/connpass.py
+++ b/app/providers/connpass.py
@@ -256,7 +256,8 @@ class ConnpassEventRequest:
                     group_url=group_url,
                     description=item["description"],
                     lat=item["lat"],
-                    lon=item["lon"]
+                    lon=item["lon"],
+                    source="connpass"
                 )
             )
         return events

--- a/app/providers/icalendar.py
+++ b/app/providers/icalendar.py
@@ -124,6 +124,7 @@ class IcalEventRequest:
                 "group_key": self.key,
                 "group_name": self.name,
                 "group_url": self.group_url,
+                "source": "icalendar",
             })
             if event.event_url is None and event.description is not None:
                 url_pattern = r'(https?://[^\s]+)'

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -23,6 +23,8 @@ class TestArchiveIndexRequest(unittest.TestCase):
         )
         self.assertEqual(events[0].event_id, None)
         self.assertEqual(events[0].group_key, "yamanashi-web")
+        # Forced to "archive" regardless of the archive JSON's own content.
+        self.assertEqual(events[0].source, "archive")
 
     def test_get_events_by_ym(self):
         archive_request = ArchiveIndexRequest(

--- a/tests/test_connpass.py
+++ b/tests/test_connpass.py
@@ -68,6 +68,7 @@ class TestConnpassEventRequest(unittest.TestCase):
         self.assertEqual(event.title, 'Test Event')
         self.assertEqual(event.description, 'This is a test event')
         self.assertEqual(event.address, 'Yamanashi, Japan')
+        self.assertEqual(event.source, 'connpass')
 
     def test_get_events(self):
         # Create a mock response with multiple events

--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -44,6 +44,7 @@ END:VCALENDAR
         self.assertEqual(events[0].group_key, "test_key")
         self.assertEqual(events[0].group_name, "Test Group")
         self.assertEqual(events[0].group_url, "http://example.com/group")
+        self.assertEqual(events[0].source, "icalendar")
 
     @patch("app.providers.icalendar.datetime")
     def test_get_events_open_status(self, mock_datetime):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -67,7 +67,8 @@ class MockConnpassEventRequest:
                 "group_url": "",
                 "description": "Description",
                 "lat": "",
-                "lon": ""
+                "lon": "",
+                "source": "connpass"
             },
             {
                 "uid": "UID 2",
@@ -91,7 +92,8 @@ class MockConnpassEventRequest:
                 "group_url": "",
                 "description": "Description",
                 "lat": "",
-                "lon": ""
+                "lon": "",
+                "source": "connpass"
             }
         ]
 
@@ -159,7 +161,8 @@ class MockICalEventRequest:
                 "group_url": "Group URL 1",
                 "description": None,
                 "lat": None,
-                "lon": None
+                "lon": None,
+                "source": "icalendar"
             }
         ]
         events = Event.from_json(json)
@@ -202,7 +205,8 @@ class MockArchiveIndexRequest:
                 "group_url": "https://example.com/yamanashi-web",
                 "description": "山梨Web勉強会の初回イベント。",
                 "lat": None,
-                "lon": None
+                "lon": None,
+                "source": "archive"
             }
         ]
         return Event.from_json(json)
@@ -263,7 +267,8 @@ class MockArchiveIndexRequestJagyamanashi(MockArchiveIndexRequest):
                 "group_url": "https://jagyamanashi.connpass.com/",
                 "description": None,
                 "lat": None,
-                "lon": None
+                "lon": None,
+                "source": "archive"
             }
         ]
         return Event.from_json(json)
@@ -999,6 +1004,12 @@ def test_read_group_events_merges_archive_when_key_matches_connpass():
               for ev in events)
     assert all(ev["group_key"] == "jagyamanashi" for ev in events
               if ev["uid"].startswith("jagyamanashi-"))
+
+    # clients can tell live connpass events apart from archived ones
+    by_uid = {ev["uid"]: ev for ev in events}
+    assert by_uid["UID 1"]["source"] == "connpass"
+    assert by_uid["UID 2"]["source"] == "connpass"
+    assert by_uid["jagyamanashi-2015-01-01-001@yamanashi-event-archive"]["source"] == "archive"
 
     # fast path (upstream pagination) must be disabled when merging archives
     assert MockConnpassEventRequest.page_requests == []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -156,6 +156,18 @@ class TestEvent(unittest.TestCase):
         event = Event.from_json(data)
         self.assertIsNone(event.source)
 
+    def test_from_json_with_unrecognized_source_defaults_to_none(self):
+        # A value outside the Literal (e.g. from a corrupted cache entry)
+        # would 500 on response_model validation if let through as-is.
+        data = {
+            "uid": "event_1@example.com", "event_id": 1, "title": "Event 1",
+            "catch": "", "hash_tag": "", "event_url": "", "started_at": "",
+            "ended_at": "", "updated_at": "", "open_status": "",
+            "source": "not-a-real-source"
+        }
+        event = Event.from_json(data)
+        self.assertIsNone(event.source)
+
     def test_to_json_with_list(self):
         # Create a list of event objects
         events = [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -112,7 +112,8 @@ class TestEvent(unittest.TestCase):
             "group_url": "Group URL",
             "description": "Description",
             "lat": "35.6895",
-            "lon": "139.6917"
+            "lon": "139.6917",
+            "source": "connpass"
         }
 
         # Call the from_json method
@@ -143,6 +144,17 @@ class TestEvent(unittest.TestCase):
         self.assertEqual(event.description, "Description")
         self.assertEqual(event.lat, "35.6895")
         self.assertEqual(event.lon, "139.6917")
+        self.assertEqual(event.source, "connpass")
+
+    def test_from_json_without_source_defaults_to_none(self):
+        # Backward compat with events cached before "source" existed.
+        data = {
+            "uid": "event_1@example.com", "event_id": 1, "title": "Event 1",
+            "catch": "", "hash_tag": "", "event_url": "", "started_at": "",
+            "ended_at": "", "updated_at": "", "open_status": ""
+        }
+        event = Event.from_json(data)
+        self.assertIsNone(event.source)
 
     def test_to_json_with_list(self):
         # Create a list of event objects
@@ -159,7 +171,7 @@ class TestEvent(unittest.TestCase):
                         place="Place", address="Address", group_key="Group Key",
                         group_name="Group Name", group_url="Group URL",
                         description="Description",
-                        lat="35.6895", lon="139.6917"),
+                        lat="35.6895", lon="139.6917", source="archive"),
             Event(uid="event_2@example.com",
                         event_id=2, title="Event 2", catch="Catch 2",
                         hash_tag="Hash Tag", event_url="Event URL",
@@ -183,6 +195,8 @@ class TestEvent(unittest.TestCase):
         self.assertEqual(len(data), 2)
         self.assertEqual(data[0]["event_id"], 1)
         self.assertEqual(data[1]["event_id"], 2)
+        self.assertEqual(data[0]["source"], "archive")
+        self.assertIsNone(data[1]["source"])
 
     def test_is_valid(self):
         event1 = Event(uid="event_1@example.com",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -157,8 +157,7 @@ class TestEvent(unittest.TestCase):
         self.assertIsNone(event.source)
 
     def test_from_json_with_unrecognized_source_defaults_to_none(self):
-        # A value outside the Literal (e.g. from a corrupted cache entry)
-        # would 500 on response_model validation if let through as-is.
+        # an unrecognized value would 500 on response_model validation otherwise
         data = {
             "uid": "event_1@example.com", "event_id": 1, "title": "Event 1",
             "catch": "", "hash_tag": "", "event_url": "", "started_at": "",


### PR DESCRIPTION
## Summary
- `Event` に `source: "connpass" | "icalendar" | "archive"` を追加し、クライアントが各イベントの出自（ライブデータかアーカイブか）を判別できるようにした
- 各プロバイダ層でタグ付け（`app/providers/connpass.py`・`icalendar.py`・`archive.py`）。`app/service.py` のマージ/relabelロジックは `group_key`/`group_name`/`group_url` のみ書き換えて `source` には触れないため、変更不要
- `Event.to_json`/`from_json` に追加。キャッシュ経由のラウンドトリップでも値が保持されることを確認済み
- 既存キャッシュ（フィールド追加前にシリアライズされたデータ）との後方互換のため `Optional`、デフォルト `None`

背景: #19 でconnpass/icalendarとarchiveが同じ`group_key`に統合されるようになった結果、イベント単体からは「これは正規データかアーカイブか」を判別する手段がなくなっていた。実際に本番のarchive index（`jagyamanashi`）に対して疎通確認し、ライブのconnpassイベント2件が`source: "connpass"`、アーカイブの過去イベント12件が`source: "archive"`として正しく判別できることを確認済み。

## Test plan
- [x] `python3 -m pytest` で既存183件全通過（新規7件含む: `test_models.py`×3, `test_connpass.py`×1, `test_icalendar.py`×1, `test_archive.py`×1, `test_main.py`のマージテスト拡張）
- [x] `TestClient` で実際に `/groups/jagyamanashi/events` を叩き、本番archive indexとconnpass APIに対してconnpass/archiveそれぞれ正しい`source`が返ることを確認