### PR TITLE
地域チャプター系グループのmember_users_countを継承しないよう修正

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -567,6 +567,8 @@ def get_groups_from_connpass_chapters(chapters, real_groups_by_key):
         # chapters carved out of the same shared group would otherwise
         # all report the same id.
         inherited.pop("id", None)
+        # member_users_count is the shared group's total, not this chapter's
+        inherited.pop("member_users_count", None)
         g = Group.from_json({
             **inherited,
             "key": entry["key"],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1762,7 +1762,7 @@ def test_get_groups_from_connpass_chapters_inherits_unset_fields():
     # real group's values instead of staying null
     assert groups[0].image_url == "https://example.com/real.png"
     assert groups[0].sub_title == "IoT platform community"
-    assert groups[0].member_users_count == 1000
+    assert groups[0].member_users_count is None
     # id belongs to the shared group; two chapters carved out of the same
     # shared group must not both report its id as their own
     assert groups[0].id is None
@@ -1894,7 +1894,7 @@ def test_request_groups_from_connpass_chapters():
     assert groups[0].url == "https://soracom-ug.connpass.com/"
     # image_url wasn't configured, so it's inherited from the real group
     assert groups[0].image_url == "https://example.com/real.png"
-    assert groups[0].member_users_count == 1000
+    assert groups[0].member_users_count is None
     # id belongs to the shared group, not this chapter
     assert groups[0].id is None
     assert last_modified == datetime.fromtimestamp(789, timezone.utc)


### PR DESCRIPTION
## Summary
- `soracomug-yamanashi` のように複数の地域チャプターが1つのconnpassグループを共有している場合、`member_users_count` は共有グループ全体の人数であり、チャプター固有の値ではない
- `get_groups_from_connpass_chapters` で実グループからフィールドを継承する際、`id` と同様に `member_users_count` も継承対象から除外し、`null` を返すよう修正

## Test plan
- [x] `pytest` (184 passed)
- [x] `test_get_groups_from_connpass_chapters_inherits_unset_fields` / `test_request_groups_from_connpass_chapters` を `member_users_count is None` を検証するよう更新

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)