### PR TITLE
各コミュニティの活動開始年・年別イベント数を返す /summary/groups を追加

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -260,3 +260,53 @@ class EventsSummary:
     granularity: str
     years: List[YearSummary]
     heatmap: List[HeatmapBucket]
+
+
+@dataclass
+class GroupYearlyActivity:
+    year: int
+    event_count: int
+
+    @staticmethod
+    def to_json(data: any):
+        if isinstance(data, list):
+            return [GroupYearlyActivity.to_json(item) for item in data]
+
+        if isinstance(data, GroupYearlyActivity):
+            return {"year": data.year, "event_count": data.event_count}
+
+        raise ValueError("data must be GroupYearlyActivity or List[GroupYearlyActivity]")
+
+
+@dataclass
+class GroupSummary:
+    key: str
+    name: str
+    image_url: Optional[str]
+    url: Optional[str]
+    start_year: Optional[int]
+    years: List[GroupYearlyActivity]
+
+    @staticmethod
+    def to_json(data: any):
+        if isinstance(data, list):
+            return [GroupSummary.to_json(item) for item in data]
+
+        if isinstance(data, GroupSummary):
+            return {
+                "key": data.key,
+                "name": data.name,
+                "image_url": data.image_url,
+                "url": data.url,
+                "start_year": data.start_year,
+                "years": GroupYearlyActivity.to_json(data.years),
+            }
+
+        raise ValueError("data must be GroupSummary or List[GroupSummary]")
+
+
+@dataclass
+class GroupsSummary:
+    from_year: int
+    to_year: int
+    groups: List[GroupSummary]

--- a/app/routes.py
+++ b/app/routes.py
@@ -543,9 +543,7 @@ async def read_events_summary_legacy(
 
 
 def build_year_counts_by_group(events: List) -> dict:
-    """Bucket events into {group_key: {year: count}} in one pass, so
-    building every group's summary doesn't rescan the full events list
-    per group (see read_groups_summary())."""
+    """Bucket events by group/year in one pass (see read_groups_summary())."""
     counts_by_group = {}
     for ev in events:
         if not ev.group_key:
@@ -557,9 +555,7 @@ def build_year_counts_by_group(events: List) -> dict:
 
 
 def build_group_summary_from_counts(group: Group, counts: dict, to_year: int) -> GroupSummary:
-    """years is trimmed to start_year..to_year -- years before a group's
-    first event are always zero, so keeping them would only inflate the
-    response."""
+    """years is trimmed to start_year..to_year (earlier years are always zero)."""
     start_year = min(counts) if counts else None
     years = [GroupYearlyActivity(year=y, event_count=counts.get(y, 0))
             for y in range(start_year, to_year + 1)] if start_year is not None else []
@@ -569,8 +565,7 @@ def build_group_summary_from_counts(group: Group, counts: dict, to_year: int) ->
 
 
 def build_group_summary(group: Group, events: List, to_year: int) -> GroupSummary:
-    """Aggregate one group's yearly event counts out of an already-fetched
-    full-history events list (see service.get_full_history())."""
+    """Aggregate one group's yearly event counts out of a full-history events list."""
     counts = {}
     for ev in events:
         if ev.group_key != group.key:

--- a/app/routes.py
+++ b/app/routes.py
@@ -117,7 +117,7 @@ async def read_events_next_week(
 async def read_events_year(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=service.MAX_EVENT_YEAR),
     keyword: str = None,
     uid: str = None,
     fields: str = None,
@@ -136,7 +136,7 @@ async def read_events_year(
 async def read_events_in_year_legacy(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=service.MAX_EVENT_YEAR),
     keyword: str = None,
     uid: str = None,
     fields: str = None,
@@ -152,7 +152,7 @@ async def read_events_in_year_legacy(
 async def read_events_month(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=service.MAX_EVENT_YEAR),
     month: int = Path(ge=1, le=12),
     keyword: str = None,
     uid: str = None,
@@ -172,7 +172,7 @@ async def read_events_month(
 async def read_events_in_year_month_legacy(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=service.MAX_EVENT_YEAR),
     month: int = Path(ge=1, le=12),
     keyword: str = None,
     uid: str = None,
@@ -189,7 +189,7 @@ async def read_events_in_year_month_legacy(
 async def read_events_day(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=service.MAX_EVENT_YEAR),
     month: int = Path(ge=1, le=12),
     day: int = Path(ge=1, le=31),
     keyword: str = None,
@@ -213,7 +213,7 @@ async def read_events_day(
 async def read_events_in_year_month_day_legacy(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=service.MAX_EVENT_YEAR),
     month: int = Path(ge=1, le=12),
     day: int = Path(ge=1, le=31),
     keyword: str = None,
@@ -232,9 +232,9 @@ async def read_events_in_year_month_day_legacy(
 async def read_events_range(
     response: Response,
     background_tasks: BackgroundTasks,
-    from_year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
+    from_year: int = Path(ge=service.MIN_EVENT_YEAR, le=service.MAX_EVENT_YEAR),
     from_month: int = Path(ge=1, le=12),
-    to_year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
+    to_year: int = Path(ge=service.MIN_EVENT_YEAR, le=service.MAX_EVENT_YEAR),
     to_month: int = Path(ge=1, le=12),
     keyword: str = None,
     uid: str = None,
@@ -264,9 +264,9 @@ async def read_events_range(
 async def read_events_fromto_year_month_legacy(
     response: Response,
     background_tasks: BackgroundTasks,
-    from_year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
+    from_year: int = Path(ge=service.MIN_EVENT_YEAR, le=service.MAX_EVENT_YEAR),
     from_month: int = Path(ge=1, le=12),
-    to_year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
+    to_year: int = Path(ge=service.MIN_EVENT_YEAR, le=service.MAX_EVENT_YEAR),
     to_month: int = Path(ge=1, le=12),
     keyword: str = None,
     uid: str = None,

--- a/app/routes.py
+++ b/app/routes.py
@@ -542,24 +542,42 @@ async def read_events_summary_legacy(
     return await read_events_summary(response, background_tasks, if_modified_since)
 
 
-def build_group_summary(group: Group, events: List, to_year: int) -> GroupSummary:
-    """Aggregate one group's yearly event counts out of an already-fetched
-    full-history events list (see service.get_full_history()). years is
-    trimmed to start_year..to_year -- years before a group's first event
-    are always zero, so keeping them would only inflate the response."""
-    counts = {}
+def build_year_counts_by_group(events: List) -> dict:
+    """Bucket events into {group_key: {year: count}} in one pass, so
+    building every group's summary doesn't rescan the full events list
+    per group (see read_groups_summary())."""
+    counts_by_group = {}
     for ev in events:
-        if ev.group_key != group.key:
+        if not ev.group_key:
             continue
         year = int(ev.started_at[:4])
+        counts = counts_by_group.setdefault(ev.group_key, {})
         counts[year] = counts.get(year, 0) + 1
+    return counts_by_group
 
+
+def build_group_summary_from_counts(group: Group, counts: dict, to_year: int) -> GroupSummary:
+    """years is trimmed to start_year..to_year -- years before a group's
+    first event are always zero, so keeping them would only inflate the
+    response."""
     start_year = min(counts) if counts else None
     years = [GroupYearlyActivity(year=y, event_count=counts.get(y, 0))
             for y in range(start_year, to_year + 1)] if start_year is not None else []
 
     return GroupSummary(key=group.key, name=group.title, image_url=group.image_url,
                         url=group.url, start_year=start_year, years=years)
+
+
+def build_group_summary(group: Group, events: List, to_year: int) -> GroupSummary:
+    """Aggregate one group's yearly event counts out of an already-fetched
+    full-history events list (see service.get_full_history())."""
+    counts = {}
+    for ev in events:
+        if ev.group_key != group.key:
+            continue
+        year = int(ev.started_at[:4])
+        counts[year] = counts.get(year, 0) + 1
+    return build_group_summary_from_counts(group, counts, to_year)
 
 
 @app.get("/summary/groups", response_model=GroupsSummary,
@@ -581,7 +599,11 @@ async def read_groups_summary(
     if is_not_modified(if_modified_since, last_modified):
         return Response(status_code=304, headers=headers)
 
-    group_summaries = [build_group_summary(group, events, to_year) for group in groups]
+    counts_by_group = build_year_counts_by_group(events)
+    group_summaries = [
+        build_group_summary_from_counts(group, counts_by_group.get(group.key, {}), to_year)
+        for group in groups
+    ]
 
     filtered = filter_model_fields(group_summaries, GroupSummary, fields)
     if filtered is None:

--- a/app/routes.py
+++ b/app/routes.py
@@ -116,7 +116,7 @@ async def read_events_next_week(
 async def read_events_year(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=2010, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
     keyword: str = None,
     uid: str = None,
     fields: str = None,
@@ -135,7 +135,7 @@ async def read_events_year(
 async def read_events_in_year_legacy(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=2010, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
     keyword: str = None,
     uid: str = None,
     fields: str = None,
@@ -151,7 +151,7 @@ async def read_events_in_year_legacy(
 async def read_events_month(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=2010, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
     month: int = Path(ge=1, le=12),
     keyword: str = None,
     uid: str = None,
@@ -171,7 +171,7 @@ async def read_events_month(
 async def read_events_in_year_month_legacy(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=2010, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
     month: int = Path(ge=1, le=12),
     keyword: str = None,
     uid: str = None,
@@ -188,7 +188,7 @@ async def read_events_in_year_month_legacy(
 async def read_events_day(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=2010, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
     month: int = Path(ge=1, le=12),
     day: int = Path(ge=1, le=31),
     keyword: str = None,
@@ -212,7 +212,7 @@ async def read_events_day(
 async def read_events_in_year_month_day_legacy(
     response: Response,
     background_tasks: BackgroundTasks,
-    year: int = Path(ge=2010, le=2040),
+    year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
     month: int = Path(ge=1, le=12),
     day: int = Path(ge=1, le=31),
     keyword: str = None,
@@ -231,9 +231,9 @@ async def read_events_in_year_month_day_legacy(
 async def read_events_range(
     response: Response,
     background_tasks: BackgroundTasks,
-    from_year: int = Path(ge=2010, le=2040),
+    from_year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
     from_month: int = Path(ge=1, le=12),
-    to_year: int = Path(ge=2010, le=2040),
+    to_year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
     to_month: int = Path(ge=1, le=12),
     keyword: str = None,
     uid: str = None,
@@ -263,9 +263,9 @@ async def read_events_range(
 async def read_events_fromto_year_month_legacy(
     response: Response,
     background_tasks: BackgroundTasks,
-    from_year: int = Path(ge=2010, le=2040),
+    from_year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
     from_month: int = Path(ge=1, le=12),
-    to_year: int = Path(ge=2010, le=2040),
+    to_year: int = Path(ge=service.MIN_EVENT_YEAR, le=2040),
     to_month: int = Path(ge=1, le=12),
     keyword: str = None,
     uid: str = None,

--- a/app/routes.py
+++ b/app/routes.py
@@ -5,6 +5,7 @@ from fastapi_mcp import FastApiMCP
 from . import service
 from .models import Event, Group
 from .models import GroupActivity, YearSummary, HeatmapBucket, EventsSummary
+from .models import GroupYearlyActivity, GroupSummary, GroupsSummary
 import hmac
 from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime, parsedate_to_datetime
@@ -539,6 +540,94 @@ async def read_events_summary_legacy(
     if_modified_since: str = Header(None)
 ):
     return await read_events_summary(response, background_tasks, if_modified_since)
+
+
+def build_group_summary(group: Group, events: List, to_year: int) -> GroupSummary:
+    """Aggregate one group's yearly event counts out of an already-fetched
+    full-history events list (see service.get_full_history()). years is
+    trimmed to start_year..to_year -- years before a group's first event
+    are always zero, so keeping them would only inflate the response."""
+    counts = {}
+    for ev in events:
+        if ev.group_key != group.key:
+            continue
+        year = int(ev.started_at[:4])
+        counts[year] = counts.get(year, 0) + 1
+
+    start_year = min(counts) if counts else None
+    years = [GroupYearlyActivity(year=y, event_count=counts.get(y, 0))
+            for y in range(start_year, to_year + 1)] if start_year is not None else []
+
+    return GroupSummary(key=group.key, name=group.title, image_url=group.image_url,
+                        url=group.url, start_year=start_year, years=years)
+
+
+@app.get("/summary/groups", response_model=GroupsSummary,
+         operation_id="summary_groups",
+         summary="Get per-group activity summary (start year and yearly event counts)")
+async def read_groups_summary(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    fields: str = None,
+    if_modified_since: str = Header(None)
+):
+    events, groups, from_year, to_year, last_modified = \
+        service.get_full_history(background_tasks)
+
+    headers = {"Cache-Control": LIST_CACHE_CONTROL}
+    if last_modified is not None:
+        headers["Last-Modified"] = format_last_modified(last_modified)
+
+    if is_not_modified(if_modified_since, last_modified):
+        return Response(status_code=304, headers=headers)
+
+    group_summaries = [build_group_summary(group, events, to_year) for group in groups]
+
+    filtered = filter_model_fields(group_summaries, GroupSummary, fields)
+    if filtered is None:
+        for key, value in headers.items():
+            response.headers[key] = value
+        return GroupsSummary(from_year=from_year, to_year=to_year, groups=group_summaries)
+
+    return JSONResponse(
+        content={"from_year": from_year, "to_year": to_year, "groups": filtered},
+        headers=headers)
+
+
+@app.get("/summary/groups/{group_key}", response_model=GroupSummary,
+         operation_id="summary_group",
+         summary="Get a single group's activity summary (start year and yearly event counts)")
+async def read_group_summary(
+    response: Response,
+    background_tasks: BackgroundTasks,
+    group_key: str,
+    fields: str = None,
+    if_modified_since: str = Header(None)
+):
+    events, groups, from_year, to_year, last_modified = \
+        service.get_full_history(background_tasks)
+
+    group = next((g for g in groups if g.key == group_key), None)
+    if group is None:
+        raise HTTPException(status_code=404,
+                            detail=f"Group '{group_key}' not found")
+
+    headers = {"Cache-Control": LIST_CACHE_CONTROL}
+    if last_modified is not None:
+        headers["Last-Modified"] = format_last_modified(last_modified)
+
+    if is_not_modified(if_modified_since, last_modified):
+        return Response(status_code=304, headers=headers)
+
+    group_summary = build_group_summary(group, events, to_year)
+
+    filtered = filter_model_fields([group_summary], GroupSummary, fields)
+    if filtered is None:
+        for key, value in headers.items():
+            response.headers[key] = value
+        return group_summary
+
+    return JSONResponse(content=filtered[0], headers=headers)
 
 
 def verify_refresh_token(x_refresh_token: str = Header(None)):

--- a/app/routes.py
+++ b/app/routes.py
@@ -466,22 +466,9 @@ async def read_events_summary(
     background_tasks: BackgroundTasks,
     if_modified_since: str = Header(None)
 ):
-    from_year = 2010
-    to_year = datetime.now().year
-
-    ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]
-
-    events, last_modified = service.get_events(
-        {"ym": ym, "keyword": None},
-        background_tasks,
-        ex=3600*24*7,  # 7 days
-        cache_ttl=3600*24)  # 24 hours
-    groups, groups_last_modified = service.get_groups({}, background_tasks)
+    events, groups, from_year, to_year, last_modified = \
+        service.get_full_history(background_tasks)
     group_by_key = {g.key: g for g in groups}
-
-    if groups_last_modified is not None:
-        last_modified = (groups_last_modified if last_modified is None
-                         else max(last_modified, groups_last_modified))
 
     headers = {"Cache-Control": LIST_CACHE_CONTROL}
     if last_modified is not None:

--- a/app/service.py
+++ b/app/service.py
@@ -375,6 +375,32 @@ def get_groups(params,
     return groups, last_modified
 
 
+def get_full_history(
+    background_tasks: BackgroundTasks = None
+) -> Tuple[List[Event], List[Group], int, int, Optional[datetime]]:
+    """Fetch every event and group in scope, from MIN_EVENT_YEAR through the
+    current year. Shared by /summary/events and /summary/groups so both
+    hit the exact same get_events() cache entry instead of independently
+    paying for the same multi-year connpass fetch.
+
+    Returns (events, groups, from_year, to_year, last_modified)."""
+    from_year = MIN_EVENT_YEAR
+    to_year = datetime.now().year
+    ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]
+
+    events, last_modified = get_events(
+        {"ym": ym, "keyword": None}, background_tasks,
+        ex=3600*24*7,  # 7 days
+        cache_ttl=3600*24)  # 24 hours
+    groups, groups_last_modified = get_groups({}, background_tasks)
+
+    if groups_last_modified is not None:
+        last_modified = (groups_last_modified if last_modified is None
+                         else max(last_modified, groups_last_modified))
+
+    return events, groups, from_year, to_year, last_modified
+
+
 def get_groups_from_cache(
     cache, params
 ) -> Tuple[Optional[List[Group]], Optional[datetime]]:

--- a/app/service.py
+++ b/app/service.py
@@ -16,6 +16,10 @@ load_dotenv()
 dirname = os.path.dirname(__file__)
 config_file = os.path.join(dirname, "config.yaml")
 
+# connpass's own service start; nothing in scope predates this, so it's the
+# floor for every from_year/ym range this app ever builds.
+MIN_EVENT_YEAR = 2010
+
 cache = EventRequestCache()
 keyword_extractor = KeywordExtractor()
 

--- a/app/service.py
+++ b/app/service.py
@@ -120,6 +120,11 @@ def request_events(params, cache_ttl: int = None,
     keyword = params["keyword"] if "keyword" in params else None
     uid = params["uid"] if "uid" in params else None
     group_key = params.get("group_key")
+    # get_full_history() (backing /summary/*) opts out: an event found
+    # only through the prefecture-wide search can never be attributed to
+    # a known group, so it's pure wasted fetch cost for a per-group
+    # summary. /events/* (the default) still wants these events.
+    include_prefecture = params.get("include_prefecture", True)
     connpass_cache_ttl = cache_ttl if cache_ttl is not None else 3600
 
     user_agent = get_user_agent(config)
@@ -134,7 +139,7 @@ def request_events(params, cache_ttl: int = None,
                     source, group_key, ym, ymd, connpass_cache_ttl, force_refresh)
 
         else:
-            if "scope" in config and "prefecture" in config["scope"]:
+            if include_prefecture and "scope" in config and "prefecture" in config["scope"]:
                 prefecture = config["scope"]["prefecture"]
                 r = ConnpassEventRequest(prefecture=prefecture,
                                          ym=ym, ymd=ymd, cache=cache,
@@ -383,13 +388,17 @@ def get_full_history(
     hit the exact same get_events() cache entry instead of independently
     paying for the same multi-year connpass fetch.
 
+    Excludes prefecture-wide (unregistered/one-off) events: neither
+    summary endpoint can attribute them to a known group, so fetching
+    them here would be pure wasted connpass load.
+
     Returns (events, groups, from_year, to_year, last_modified)."""
     from_year = MIN_EVENT_YEAR
     to_year = datetime.now().year
     ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]
 
     events, last_modified = get_events(
-        {"ym": ym, "keyword": None}, background_tasks,
+        {"ym": ym, "keyword": None, "include_prefecture": False}, background_tasks,
         ex=3600*24*7,  # 7 days
         cache_ttl=3600*24)  # 24 hours
     groups, groups_last_modified = get_groups({}, background_tasks)

--- a/app/service.py
+++ b/app/service.py
@@ -16,8 +16,7 @@ load_dotenv()
 dirname = os.path.dirname(__file__)
 config_file = os.path.join(dirname, "config.yaml")
 
-# connpass's own service start; nothing in scope predates this, so it's the
-# floor for every from_year/ym range this app ever builds.
+# connpass's own service start; the floor for every from_year/ym range.
 MIN_EVENT_YEAR = 2010
 
 cache = EventRequestCache()
@@ -120,10 +119,7 @@ def request_events(params, cache_ttl: int = None,
     keyword = params["keyword"] if "keyword" in params else None
     uid = params["uid"] if "uid" in params else None
     group_key = params.get("group_key")
-    # get_full_history() (backing /summary/*) opts out: an event found
-    # only through the prefecture-wide search can never be attributed to
-    # a known group, so it's pure wasted fetch cost for a per-group
-    # summary. /events/* (the default) still wants these events.
+    # get_full_history() (backing /summary/*) opts out of this query.
     include_prefecture = params.get("include_prefecture", True)
     connpass_cache_ttl = cache_ttl if cache_ttl is not None else 3600
 
@@ -401,14 +397,11 @@ def get_groups(params,
 def get_full_history(
     background_tasks: BackgroundTasks = None
 ) -> Tuple[List[Event], List[Group], int, int, Optional[datetime]]:
-    """Fetch every event and group in scope, from MIN_EVENT_YEAR through the
-    current year. Shared by /summary/events and /summary/groups so both
-    hit the exact same get_events() cache entry instead of independently
-    paying for the same multi-year connpass fetch.
-
-    Excludes prefecture-wide (unregistered/one-off) events by design: both
-    /summary/events and /summary/groups intentionally report only known-
-    community activity, not the broader unaffiliated event landscape.
+    """Fetch every event/group from MIN_EVENT_YEAR through the current year.
+    Shared by /summary/events and /summary/groups so both hit the same
+    get_events() cache entry. Excludes prefecture-wide (unregistered/
+    one-off) events by design -- both endpoints report known-community
+    activity only.
 
     Returns (events, groups, from_year, to_year, last_modified)."""
     from_year = MIN_EVENT_YEAR

--- a/app/service.py
+++ b/app/service.py
@@ -406,9 +406,9 @@ def get_full_history(
     hit the exact same get_events() cache entry instead of independently
     paying for the same multi-year connpass fetch.
 
-    Excludes prefecture-wide (unregistered/one-off) events: neither
-    summary endpoint can attribute them to a known group, so fetching
-    them here would be pure wasted connpass load.
+    Excludes prefecture-wide (unregistered/one-off) events by design: both
+    /summary/events and /summary/groups intentionally report only known-
+    community activity, not the broader unaffiliated event landscape.
 
     Returns (events, groups, from_year, to_year, last_modified)."""
     from_year = MIN_EVENT_YEAR

--- a/app/service.py
+++ b/app/service.py
@@ -18,6 +18,8 @@ config_file = os.path.join(dirname, "config.yaml")
 
 # connpass's own service start; the floor for every from_year/ym range.
 MIN_EVENT_YEAR = 2010
+# Generous sanity ceiling for year path params; no real-world meaning.
+MAX_EVENT_YEAR = 2040
 
 cache = EventRequestCache()
 keyword_extractor = KeywordExtractor()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1222,6 +1222,8 @@ def test_read_group_summary(mock_get_groups_from_icalendar):
     assert data["years"][0] == {"year": 2012, "event_count": 1}
 
 
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.service.IcalEventRequest", MockICalEventRequest)
 @patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
 @patch("app.service.get_groups_from_icalendar")
 @patch("app.service.cache", EventRequestCache(prefix="test_summary_group_404_"))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1156,6 +1156,112 @@ def test_read_events_summary_uses_extended_ttls(mock_get_groups_from_icalendar):
     assert 3600 * 24 * 6 < remaining <= 3600 * 24 * 7
 
 
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.service.IcalEventRequest", MockICalEventRequest)
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+@patch("app.service.cache", EventRequestCache(prefix="test_summary_groups_"))
+def test_read_groups_summary(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/summary/groups")
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "public, no-cache"
+    assert "Last-Modified" in response.headers
+
+    data = response.json()
+    assert data["from_year"] == 2010
+    to_year = data["to_year"]
+
+    by_key = {g["key"]: g for g in data["groups"]}
+
+    # Archive mock event: 2012-05-19, group_key "yamanashi-web"
+    web = by_key["yamanashi-web"]
+    assert web["start_year"] == 2012
+    assert web["years"][0] == {"year": 2012, "event_count": 1}
+    assert web["years"][-1] == {"year": to_year, "event_count": 0}
+    assert len(web["years"]) == to_year - 2012 + 1
+
+    # A group with no events anywhere in range gets a null start_year and
+    # an empty years list, not a list zero-filled back to from_year
+    assert by_key["Key"]["start_year"] is None
+    assert by_key["Key"]["years"] == []
+
+
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.service.IcalEventRequest", MockICalEventRequest)
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+@patch("app.service.cache", EventRequestCache(prefix="test_summary_groups_fields_"))
+def test_read_groups_summary_with_fields(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/summary/groups", params={"fields": "key,name,start_year"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["groups"]) > 0
+    for group in data["groups"]:
+        assert set(group.keys()) == {"key", "name", "start_year"}
+
+
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.service.IcalEventRequest", MockICalEventRequest)
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+@patch("app.service.cache", EventRequestCache(prefix="test_summary_group_"))
+def test_read_group_summary(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/summary/groups/yamanashi-web")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["key"] == "yamanashi-web"
+    assert data["start_year"] == 2012
+    assert data["years"][0] == {"year": 2012, "event_count": 1}
+
+
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+@patch("app.service.cache", EventRequestCache(prefix="test_summary_group_404_"))
+def test_read_group_summary_not_found(mock_get_groups_from_icalendar):
+    mock_get_groups_from_icalendar.return_value = []
+
+    response = client.get("/summary/groups/no-such-group")
+    assert response.status_code == 404
+
+
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
+@patch("app.service.IcalEventRequest", MockICalEventRequest)
+@patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
+@patch("app.service.get_groups_from_icalendar")
+@patch("app.service.cache", EventRequestCache(prefix="test_summary_shared_cache_"))
+def test_read_groups_summary_reuses_events_summary_cache(mock_get_groups_from_icalendar):
+    """/summary/groups must issue the exact same get_events() params as
+    /summary/events (same ym range, same keyword=None), so once
+    /summary/events has warmed the cache, /summary/groups is served from
+    it instead of paying for a second full-history connpass fetch."""
+    mock_get_groups_from_icalendar.return_value = []
+
+    events_response = client.get("/summary/events")
+    assert events_response.status_code == 200
+
+    from_year = service.MIN_EVENT_YEAR
+    to_year = datetime.now().year
+    ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]
+    params = normalize_event_params({"ym": ym, "keyword": None})
+
+    # The background revalidation triggered by /summary/events must have
+    # already populated this exact cache entry by the time the request
+    # returns (TestClient runs BackgroundTasks synchronously).
+    cached_events, _ = service.get_events_from_cache(service.cache, params)
+    assert cached_events is not None
+
+    groups_response = client.get("/summary/groups")
+    assert groups_response.status_code == 200
+    assert groups_response.json()["to_year"] == to_year
+
+
 @patch("app.service.ConnpassGroupRequest", MockConnpassGroupRequest)
 @patch("app.service.get_groups_from_icalendar")
 def test_read_group(mock_get_groups_from_icalendar):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1028,7 +1028,7 @@ def test_read_events_summary(mock_get_groups_from_icalendar):
     assert "Last-Modified" in response.headers
 
     data = response.json()
-    assert data["from_year"] == 2010
+    assert data["from_year"] == service.MIN_EVENT_YEAR
     assert data["granularity"] == "month"
     assert len(data["years"]) == data["to_year"] - data["from_year"] + 1
 
@@ -1082,7 +1082,7 @@ def test_read_events_summary_legacy_path_still_works(mock_get_groups_from_icalen
     response = client.get("/events/summary")
     assert response.status_code == 200
     data = response.json()
-    assert data["from_year"] == 2010
+    assert data["from_year"] == service.MIN_EVENT_YEAR
     assert data["granularity"] == "month"
 
 
@@ -1146,7 +1146,7 @@ def test_read_events_summary_uses_extended_ttls(mock_get_groups_from_icalendar):
     # entry) must use a 7 day expiry, not the default 72 hours used by
     # the other /events endpoints. The years/heatmap payload built from
     # it is not itself cached and is recomputed on every request.
-    from_year = 2010
+    from_year = service.MIN_EVENT_YEAR
     to_year = datetime.now().year
     ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]
     params = normalize_event_params(
@@ -1171,7 +1171,7 @@ def test_read_groups_summary(mock_get_groups_from_icalendar):
     assert "Last-Modified" in response.headers
 
     data = response.json()
-    assert data["from_year"] == 2010
+    assert data["from_year"] == service.MIN_EVENT_YEAR
     to_year = data["to_year"]
 
     by_key = {g["key"]: g for g in data["groups"]}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1183,8 +1183,7 @@ def test_read_groups_summary(mock_get_groups_from_icalendar):
     assert web["years"][-1] == {"year": to_year, "event_count": 0}
     assert len(web["years"]) == to_year - 2012 + 1
 
-    # A group with no events anywhere in range gets a null start_year and
-    # an empty years list, not a list zero-filled back to from_year
+    # No events in range -> null start_year, empty years (not zero-filled).
     assert by_key["Key"]["start_year"] is None
     assert by_key["Key"]["years"] == []
 
@@ -1255,9 +1254,8 @@ def test_read_groups_summary_reuses_events_summary_cache(mock_get_groups_from_ic
     params = normalize_event_params(
         {"ym": ym, "keyword": None, "include_prefecture": False})
 
-    # The background revalidation triggered by /summary/events must have
-    # already populated this exact cache entry by the time the request
-    # returns (TestClient runs BackgroundTasks synchronously).
+    # TestClient runs BackgroundTasks synchronously, so the cache must
+    # already be warm by the time /summary/events returns.
     cached_events, _ = service.get_events_from_cache(service.cache, params)
     assert cached_events is not None
 
@@ -1995,8 +1993,7 @@ def test_request_events_includes_prefecture_query_by_default():
 
     request_events({})
 
-    # /events/* (the default) still wants unregistered/one-off events
-    # found only through the prefecture-wide search.
+    # /events/* (the default) still wants the prefecture-wide search.
     prefecture_calls = [c for c in MockConnpassEventRequestCountingCalls.instances
                         if c.get("prefecture")]
     assert len(prefecture_calls) == 1
@@ -2016,9 +2013,7 @@ def test_request_events_excludes_prefecture_query_when_opted_out():
 
     request_events({"include_prefecture": False})
 
-    # get_full_history() (backing /summary/*) opts out: an event found
-    # only through the prefecture-wide search can never be attributed to
-    # a known group, so fetching it would be pure wasted connpass load.
+    # get_full_history() (backing /summary/*) opts out of this query.
     prefecture_calls = [c for c in MockConnpassEventRequestCountingCalls.instances
                         if c.get("prefecture")]
     assert prefecture_calls == []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1149,7 +1149,8 @@ def test_read_events_summary_uses_extended_ttls(mock_get_groups_from_icalendar):
     from_year = 2010
     to_year = datetime.now().year
     ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]
-    params = normalize_event_params({"ym": ym, "keyword": None})
+    params = normalize_event_params(
+        {"ym": ym, "keyword": None, "include_prefecture": False})
     key = service_module.cache.generate_key(params) + ":content"
     expiry = service_module.cache._expiry[key]
     remaining = expiry - datetime.now(timezone.utc).timestamp()
@@ -1249,7 +1250,8 @@ def test_read_groups_summary_reuses_events_summary_cache(mock_get_groups_from_ic
     from_year = service.MIN_EVENT_YEAR
     to_year = datetime.now().year
     ym = [f"{y:04}{m:02}" for y in range(from_year, to_year + 1) for m in range(1, 13)]
-    params = normalize_event_params({"ym": ym, "keyword": None})
+    params = normalize_event_params(
+        {"ym": ym, "keyword": None, "include_prefecture": False})
 
     # The background revalidation triggered by /summary/events must have
     # already populated this exact cache entry by the time the request
@@ -1920,6 +1922,51 @@ class MockConnpassEventRequestCountingCalls:
 
     def get_last_modified(self):
         return datetime.fromtimestamp(456, timezone.utc)
+
+
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequestCountingCalls)
+@patch("app.service.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "prefecture": ["山梨県"],
+        "connpass": [{"subdomain": "jagyamanashi"}]
+    }
+})
+def test_request_events_includes_prefecture_query_by_default():
+    MockConnpassEventRequestCountingCalls.instances = []
+
+    request_events({})
+
+    # /events/* (the default) still wants unregistered/one-off events
+    # found only through the prefecture-wide search.
+    prefecture_calls = [c for c in MockConnpassEventRequestCountingCalls.instances
+                        if c.get("prefecture")]
+    assert len(prefecture_calls) == 1
+    assert prefecture_calls[0]["prefecture"] == ["山梨県"]
+
+
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequestCountingCalls)
+@patch("app.service.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "prefecture": ["山梨県"],
+        "connpass": [{"subdomain": "jagyamanashi"}]
+    }
+})
+def test_request_events_excludes_prefecture_query_when_opted_out():
+    MockConnpassEventRequestCountingCalls.instances = []
+
+    request_events({"include_prefecture": False})
+
+    # get_full_history() (backing /summary/*) opts out: an event found
+    # only through the prefecture-wide search can never be attributed to
+    # a known group, so fetching it would be pure wasted connpass load.
+    prefecture_calls = [c for c in MockConnpassEventRequestCountingCalls.instances
+                        if c.get("prefecture")]
+    assert prefecture_calls == []
+    assert len(MockConnpassEventRequestCountingCalls.instances) == 1
+    assert MockConnpassEventRequestCountingCalls.instances[0]["subdomain"] == \
+        ["jagyamanashi"]
 
 
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequestCountingCalls)


### PR DESCRIPTION
## Summary
- `member_users_count`（#21で共有connpassグループの人数を返してしまう問題を修正済み）に代わり、各コミュニティの活動状況を示す指標として `start_year`（初回イベントの年）と年別イベント数を返す `GET /summary/groups` / `GET /summary/groups/{group_key}` を追加
- `/summary/events` と `/summary/groups` は内部で同じ `service.get_full_history()`（同一の `ym`/`keyword=None` パラメータでの `get_events()` 呼び出し）を共有し、同一のconnpassキャッシュエントリにヒットするため、追加のconnpass APIリクエストは発生しない
- 各所に散らばっていた `2010`（イベント年の下限）を `service.MIN_EVENT_YEAR` として一元化
- `get_full_history()` はプレフェクチャ横断(`keyword_or=山梨県`, subdomain指定なし)のconnpassクエリを実行しないよう変更。未登録・単発イベントは既知グループに紐付けられずどちらのsummaryエンドポイントの出力にも反映されないため、取得しても無駄になる(実測で361件相当のリクエスト量)。`/events` 系は従来通りこのクエリを含む(`request_events()` に `include_prefecture`（デフォルト `True`）を追加し、`get_full_history()` だけ `False` を渡す形)

## Details
- `years` は `start_year`〜`to_year` のみを含む（`start_year` より前は構造的に必ず0件なのでレスポンスサイズ削減のため省略）
- 該当期間中に1件もイベントが無いグループは `start_year: null`, `years: []`
- 両エンドポインとも既存の `fields=` フィルタリングに対応（`/groups`, `/events` と同じ仕組み）
- `/summary/groups/{group_key}` は未知のキーで404

## Test plan
- [x] `pytest`（191 passed）
- [x] 実際のarchiveインデックス(`https://yuukis.github.io/yamanashi-event-archive/index.json`)に対して手動でエンドツーエンド確認し、`yamanashi-wordpress-meetup` などで妥当な `start_year`/`years` が返ることを確認
- [x] `/summary/groups` が `/summary/events` で温まったキャッシュを再利用し、追加のconnpassフェッチを発生させないことをテストで担保
- [x] 本番connpass APIに対して `include_prefecture=False` 時にプレフェクチャクエリが発行されないこと、デフォルトでは発行されることを実行確認
- [x] 各コミット単体でのimport・テスト可否をworktreeで確認(CI未設定環境でも実ネットワークに依存しないことを含む)
- [x] CI green (`gh pr checks 23`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
