### PR TITLE
チャプター系connpassグループをkeyword指定で分離取得し負荷を削減

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -166,9 +166,16 @@ def request_events(params, cache_ttl: int = None,
             # is broader than a title match (see its docstring).
             chapters_by_subdomain = group_chapters_by_subdomain(chapters)
             for chapter_subdomain, entries in chapters_by_subdomain.items():
+                # dict.fromkeys, not a plain list: a misconfigured scope
+                # with repeated chapter entries (or entries that happen to
+                # share a title_keyword) must not leak a duplicate
+                # keyword into the query -- same reasoning as the plain
+                # subdomain dedup above.
+                keywords = list(dict.fromkeys(
+                    entry["title_keyword"] for entry in entries))
                 r = ConnpassEventRequest(
                     subdomain=[chapter_subdomain],
-                    keyword=[entry["title_keyword"] for entry in entries],
+                    keyword=keywords,
                     ym=ym, ymd=ymd, cache=cache,
                     api_key=connpass_api_key,
                     user_agent=user_agent,

--- a/app/service.py
+++ b/app/service.py
@@ -531,16 +531,24 @@ def merged_connpass_subdomains(plain_subdomains, chapters):
     return list(merged)
 
 
+def group_chapters_by_subdomain(chapters):
+    grouped = {}
+    for entry in chapters:
+        grouped.setdefault(entry["subdomain"], []).append(entry)
+    return grouped
+
+
 def partition_and_relabel_chapter_events(events, chapters):
-    # Matched against the title only, not sent to connpass as a `keyword`
-    # search param: connpass's keyword search also matches description/
-    # address text, which would pull in other chapters' events.
+    # The exact title substring match here is the source of truth, even
+    # when the caller already pre-filtered upstream via connpass's own
+    # `keyword` search (see request_events()) -- that search also matches
+    # description/address text, so it can still return other chapters'
+    # events (sharing the same subdomain); this re-check is what actually
+    # keeps only the ones belonging to this chapter.
     if not chapters:
         return events
 
-    entries_by_subdomain = {}
-    for entry in chapters:
-        entries_by_subdomain.setdefault(entry["subdomain"], []).append(entry)
+    entries_by_subdomain = group_chapters_by_subdomain(chapters)
 
     result = []
     for ev in events:

--- a/app/service.py
+++ b/app/service.py
@@ -143,18 +143,40 @@ def request_events(params, cache_ttl: int = None,
                 last_modified = max(last_modified, r.get_last_modified())
 
             plain_subdomains, chapters = split_connpass_scope(config)
-            subdomain = merged_connpass_subdomains(plain_subdomains, chapters)
 
-            if len(subdomain) > 0:
-                r = ConnpassEventRequest(subdomain=subdomain,
+            if len(plain_subdomains) > 0:
+                r = ConnpassEventRequest(subdomain=plain_subdomains,
                                          ym=ym, ymd=ymd, cache=cache,
                                          api_key=connpass_api_key,
                                          user_agent=user_agent,
                                          cache_ttl=connpass_cache_ttl,
                                          skip_cache=force_refresh
                                          )
+                events += r.get_events()
+                last_modified = max(last_modified, r.get_last_modified())
+
+            # Chapters are fetched separately, one request per shared
+            # subdomain, with their title_keyword(s) passed as connpass's
+            # `keyword` filter -- a subdomain shared with other chapters
+            # (e.g. a nationwide group) can carry far more history than
+            # this chapter's own share of it, so narrowing upstream avoids
+            # paginating through all of it just to extract a handful of
+            # relevant events. partition_and_relabel_chapter_events() still
+            # re-checks the title exactly, since connpass's keyword search
+            # is broader than a title match (see its docstring).
+            chapters_by_subdomain = group_chapters_by_subdomain(chapters)
+            for chapter_subdomain, entries in chapters_by_subdomain.items():
+                r = ConnpassEventRequest(
+                    subdomain=[chapter_subdomain],
+                    keyword=[entry["title_keyword"] for entry in entries],
+                    ym=ym, ymd=ymd, cache=cache,
+                    api_key=connpass_api_key,
+                    user_agent=user_agent,
+                    cache_ttl=connpass_cache_ttl,
+                    skip_cache=force_refresh
+                )
                 events += partition_and_relabel_chapter_events(
-                    r.get_events(), chapters)
+                    r.get_events(), entries)
                 last_modified = max(last_modified, r.get_last_modified())
 
             if "scope" in config and "icalendar" in config["scope"]:

--- a/app/service.py
+++ b/app/service.py
@@ -540,6 +540,12 @@ def split_connpass_scope(config):
             "(title_keyword set) -- a subdomain can only be one or the "
             "other")
 
+    # dict.fromkeys, not set(): dedupes a config with repeated plain
+    # entries while preserving order, so callers building a connpass
+    # request straight from this list get a stable query/cache key
+    # regardless of accidental duplicates in scope.connpass.
+    plain = list(dict.fromkeys(plain))
+
     return plain, chapters
 
 

--- a/app/service.py
+++ b/app/service.py
@@ -155,22 +155,11 @@ def request_events(params, cache_ttl: int = None,
                 events += r.get_events()
                 last_modified = max(last_modified, r.get_last_modified())
 
-            # Chapters are fetched separately, one request per shared
-            # subdomain, with their title_keyword(s) passed as connpass's
-            # `keyword` filter -- a subdomain shared with other chapters
-            # (e.g. a nationwide group) can carry far more history than
-            # this chapter's own share of it, so narrowing upstream avoids
-            # paginating through all of it just to extract a handful of
-            # relevant events. partition_and_relabel_chapter_events() still
-            # re-checks the title exactly, since connpass's keyword search
-            # is broader than a title match (see its docstring).
+            # Chapters are fetched separately, per shared subdomain, with
+            # title_keyword(s) sent upstream as connpass's `keyword` filter
+            # to avoid paginating through the whole shared subdomain.
             chapters_by_subdomain = group_chapters_by_subdomain(chapters)
             for chapter_subdomain, entries in chapters_by_subdomain.items():
-                # dict.fromkeys, not a plain list: a misconfigured scope
-                # with repeated chapter entries (or entries that happen to
-                # share a title_keyword) must not leak a duplicate
-                # keyword into the query -- same reasoning as the plain
-                # subdomain dedup above.
                 keywords = list(dict.fromkeys(
                     entry["title_keyword"] for entry in entries))
                 r = ConnpassEventRequest(
@@ -547,10 +536,7 @@ def split_connpass_scope(config):
             "(title_keyword set) -- a subdomain can only be one or the "
             "other")
 
-    # dict.fromkeys, not set(): dedupes a config with repeated plain
-    # entries while preserving order, so callers building a connpass
-    # request straight from this list get a stable query/cache key
-    # regardless of accidental duplicates in scope.connpass.
+    # dict.fromkeys: dedupes repeated plain entries while preserving order.
     plain = list(dict.fromkeys(plain))
 
     return plain, chapters
@@ -574,12 +560,9 @@ def group_chapters_by_subdomain(chapters):
 
 
 def partition_and_relabel_chapter_events(events, chapters):
-    # The exact title substring match here is the source of truth, even
-    # when the caller already pre-filtered upstream via connpass's own
-    # `keyword` search (see request_events()) -- that search also matches
-    # description/address text, so it can still return other chapters'
-    # events (sharing the same subdomain); this re-check is what actually
-    # keeps only the ones belonging to this chapter.
+    # Exact title match is the source of truth: request_events()'s
+    # upstream `keyword` pre-filter is broader (also scans description/
+    # address), so it can still return other chapters' events too.
     if not chapters:
         return events
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1586,10 +1586,7 @@ def test_split_connpass_scope_separates_plain_and_chapter_entries():
 
 
 def test_split_connpass_scope_dedupes_repeated_plain_entries():
-    # A misconfigured scope.connpass with the same plain subdomain listed
-    # twice must not leak duplicates into callers that build a connpass
-    # request straight from `plain` -- a duplicate subdomain would shift
-    # the request's query params (and cache key) for no reason.
+    # A duplicate plain subdomain in config must not leak into `plain`.
     config = {
         "scope": {
             "connpass": [
@@ -1849,17 +1846,14 @@ def test_request_events_chapter_query_passes_title_keyword_upstream():
 
     events, _ = request_events({})
 
-    # The chapter's title_keyword is sent to connpass as a narrowing
-    # `keyword` filter, so a shared subdomain's unrelated history isn't
-    # paginated through just to extract this chapter's events.
+    # title_keyword is sent to connpass as a narrowing `keyword` filter.
     assert len(MockConnpassEventRequestCapturingKwargs.instances) == 1
     call = MockConnpassEventRequestCapturingKwargs.instances[0]
     assert call["subdomain"] == ["soracomug-tokyo"]
     assert call["keyword"] == ["山梨"]
 
-    # connpass's keyword search is broader than a title match (it also
-    # scans description/address), so the exact title re-check must still
-    # drop the Tokyo event whose *description* happens to mention 山梨.
+    # Exact title re-check must still drop the Tokyo event whose
+    # *description* happens to mention 山梨.
     assert len(events) == 1
     assert events[0].uid == "UID Yamanashi 1"
     assert events[0].group_key == "soracomug-yamanashi"
@@ -1890,11 +1884,7 @@ def test_request_events_fetches_chapters_separately_from_plain_subdomains():
 
     request_events({})
 
-    # Plain subdomains and chapters must NOT share a query: a chapter's
-    # subdomain can be shared with other, unrelated chapters (e.g. a
-    # nationwide group), so mixing it into the plain-subdomain query would
-    # force paginating through all of that shared history on every request
-    # instead of narrowing it upstream with `keyword` (see below).
+    # Plain subdomains and chapters must NOT share a query.
     assert len(MockConnpassEventRequestCountingCalls.instances) == 2
 
     by_subdomain = {tuple(c["subdomain"]): c

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1585,6 +1585,26 @@ def test_split_connpass_scope_separates_plain_and_chapter_entries():
     assert chapters == [CHAPTER_ENTRY]
 
 
+def test_split_connpass_scope_dedupes_repeated_plain_entries():
+    # A misconfigured scope.connpass with the same plain subdomain listed
+    # twice must not leak duplicates into callers that build a connpass
+    # request straight from `plain` -- a duplicate subdomain would shift
+    # the request's query params (and cache key) for no reason.
+    config = {
+        "scope": {
+            "connpass": [
+                {"subdomain": "jagyamanashi"},
+                {"subdomain": "coderdojokofu"},
+                {"subdomain": "jagyamanashi"},
+            ]
+        }
+    }
+
+    plain, _ = split_connpass_scope(config)
+
+    assert plain == ["jagyamanashi", "coderdojokofu"]
+
+
 @pytest.mark.parametrize("title_keyword", [None, ""])
 def test_split_connpass_scope_rejects_empty_title_keyword(title_keyword):
     config = {
@@ -1883,6 +1903,25 @@ def test_request_events_fetches_chapters_separately_from_plain_subdomains():
 
     assert by_subdomain[("jagyamanashi",)].get("keyword") is None
     assert by_subdomain[("soracomug-tokyo",)]["keyword"] == ["山梨"]
+
+
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequestCountingCalls)
+@patch("app.service.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "connpass": [{"subdomain": "jagyamanashi"}, {"subdomain": "jagyamanashi"}]
+    }
+})
+def test_request_events_plain_query_dedupes_repeated_subdomain():
+    MockConnpassEventRequestCountingCalls.instances = []
+
+    request_events({})
+
+    # A misconfigured duplicate plain entry must not reach the connpass
+    # request -- it would shift the query params/cache key for no reason.
+    assert len(MockConnpassEventRequestCountingCalls.instances) == 1
+    assert MockConnpassEventRequestCountingCalls.instances[0]["subdomain"] == \
+        ["jagyamanashi"]
 
 
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequestCountingCalls)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1949,6 +1949,29 @@ def test_request_events_dedupes_repeated_chapter_subdomain():
     assert set(call["keyword"]) == {"山梨", "Tokyo"}
 
 
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequestCountingCalls)
+@patch("app.service.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        # Two chapters sharing a subdomain AND (accidentally) the same
+        # title_keyword
+        "connpass": [
+            CHAPTER_ENTRY,
+            {**CHAPTER_ENTRY, "key": "soracomug-yamanashi-2"}
+        ]
+    }
+})
+def test_request_events_dedupes_repeated_chapter_keyword():
+    MockConnpassEventRequestCountingCalls.instances = []
+
+    request_events({})
+
+    # A misconfigured duplicate title_keyword must not reach the connpass
+    # request -- it would shift the query params/cache key for no reason.
+    assert len(MockConnpassEventRequestCountingCalls.instances) == 1
+    assert MockConnpassEventRequestCountingCalls.instances[0]["keyword"] == ["山梨"]
+
+
 class MockConnpassGroupRequestForChapters:
     def __init__(self, **kwargs):
         pass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1800,6 +1800,51 @@ def test_request_events_from_connpass_chapters():
     assert last_modified == datetime.fromtimestamp(456, timezone.utc)
 
 
+class MockConnpassEventRequestCapturingKwargs:
+    instances = []
+
+    def __init__(self, **kwargs):
+        MockConnpassEventRequestCapturingKwargs.instances.append(kwargs)
+
+    def get_events(self):
+        return [
+            _make_subgroup_event("UID Yamanashi 1", "SORACOM UG 山梨 #1"),
+            _make_subgroup_event("UID Tokyo 1", "SORACOM UG Tokyo #1",
+                                 description="山梨から来たゲストを迎えます"),
+        ]
+
+    def get_last_modified(self):
+        return datetime.fromtimestamp(456, timezone.utc)
+
+
+@patch("app.service.ConnpassEventRequest", MockConnpassEventRequestCapturingKwargs)
+@patch("app.service.config", {
+    "metadata": {"version": "1.0.0"},
+    "scope": {
+        "connpass": [CHAPTER_ENTRY]
+    }
+})
+def test_request_events_chapter_query_passes_title_keyword_upstream():
+    MockConnpassEventRequestCapturingKwargs.instances = []
+
+    events, _ = request_events({})
+
+    # The chapter's title_keyword is sent to connpass as a narrowing
+    # `keyword` filter, so a shared subdomain's unrelated history isn't
+    # paginated through just to extract this chapter's events.
+    assert len(MockConnpassEventRequestCapturingKwargs.instances) == 1
+    call = MockConnpassEventRequestCapturingKwargs.instances[0]
+    assert call["subdomain"] == ["soracomug-tokyo"]
+    assert call["keyword"] == ["山梨"]
+
+    # connpass's keyword search is broader than a title match (it also
+    # scans description/address), so the exact title re-check must still
+    # drop the Tokyo event whose *description* happens to mention 山梨.
+    assert len(events) == 1
+    assert events[0].uid == "UID Yamanashi 1"
+    assert events[0].group_key == "soracomug-yamanashi"
+
+
 class MockConnpassEventRequestCountingCalls:
     instances = []
 
@@ -1807,10 +1852,7 @@ class MockConnpassEventRequestCountingCalls:
         MockConnpassEventRequestCountingCalls.instances.append(kwargs)
 
     def get_events(self):
-        return [
-            _make_subgroup_event("UID Yamanashi 1", "SORACOM UG 山梨 #1"),
-            _make_subgroup_event("UID Tokyo 1", "SORACOM UG Tokyo #1"),
-        ]
+        return []
 
     def get_last_modified(self):
         return datetime.fromtimestamp(456, timezone.utc)
@@ -1823,18 +1865,24 @@ class MockConnpassEventRequestCountingCalls:
         "connpass": [{"subdomain": "jagyamanashi"}, CHAPTER_ENTRY]
     }
 })
-def test_request_events_merges_chapters_into_single_subdomain_query():
+def test_request_events_fetches_chapters_separately_from_plain_subdomains():
     MockConnpassEventRequestCountingCalls.instances = []
 
-    events, _ = request_events({})
+    request_events({})
 
-    # Plain and chapter entries under scope.connpass must share a single
-    # ConnpassEventRequest call (no extra connpass query per chapter).
-    assert len(MockConnpassEventRequestCountingCalls.instances) == 1
-    called_subdomain = MockConnpassEventRequestCountingCalls.instances[0]["subdomain"]
-    assert set(called_subdomain) == {"jagyamanashi", "soracomug-tokyo"}
-    assert len(events) == 1
-    assert events[0].group_key == "soracomug-yamanashi"
+    # Plain subdomains and chapters must NOT share a query: a chapter's
+    # subdomain can be shared with other, unrelated chapters (e.g. a
+    # nationwide group), so mixing it into the plain-subdomain query would
+    # force paginating through all of that shared history on every request
+    # instead of narrowing it upstream with `keyword` (see below).
+    assert len(MockConnpassEventRequestCountingCalls.instances) == 2
+
+    by_subdomain = {tuple(c["subdomain"]): c
+                    for c in MockConnpassEventRequestCountingCalls.instances}
+    assert set(by_subdomain.keys()) == {("jagyamanashi",), ("soracomug-tokyo",)}
+
+    assert by_subdomain[("jagyamanashi",)].get("keyword") is None
+    assert by_subdomain[("soracomug-tokyo",)]["keyword"] == ["山梨"]
 
 
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequestCountingCalls)
@@ -1854,8 +1902,12 @@ def test_request_events_dedupes_repeated_chapter_subdomain():
 
     request_events({})
 
-    called_subdomain = MockConnpassEventRequestCountingCalls.instances[0]["subdomain"]
-    assert called_subdomain == ["soracomug-tokyo"]
+    # Still a single request for the shared subdomain, with both chapters'
+    # title_keyword sent together as connpass's OR-matched keyword filter.
+    assert len(MockConnpassEventRequestCountingCalls.instances) == 1
+    call = MockConnpassEventRequestCountingCalls.instances[0]
+    assert call["subdomain"] == ["soracomug-tokyo"]
+    assert set(call["keyword"]) == {"山梨", "Tokyo"}
 
 
 class MockConnpassGroupRequestForChapters:


### PR DESCRIPTION
## Summary
- `soracomug-yamanashi` のように共有connpassグループ配下のチャプターは、これまで他の地域グループと同じ結合クエリに`subdomain`だけで混ぜられ、connpassからはそのサブドメインの全イベント(他チャプター分含む)が無フィルタで返され、タイトル一致チェックはクライアント側でのみ行っていた
- 本番connpass APIに実際に問い合わせたところ、`soracomug-tokyo` は全期間363件のイベントを持つが「山梨」に一致するのはわずか2件で、取得していた分の99%以上がその場で捨てられていた
- チャプターのsubdomainは結合クエリから分離し、共有subdomainごとに専用リクエストを発行、`title_keyword`をconnpassの`keyword`パラメータとして渡すことで、connpass側で事前に絞り込む
- `keyword`検索はdescription/addressも対象になり得るため広めのヒットを返すが、`partition_and_relabel_chapter_events()`による厳密なタイトル一致チェックはそのまま残しており、最終的な挙動・出力は変わらない(絞り込みが早まるだけ)

## Details
- Copilotレビュー指摘への対応: `plain_subdomains` を `merged_connpass_subdomains()` 経由せず直接使うようになったことで重複除去が漏れていたため、`split_connpass_scope()` 側で `plain` を重複除去するよう修正(`request_groups()` の既存呼び出しにも影響なし、重複除去済みリストへの再適用は無害)

## Test plan
- [x] `pytest`(187 passed)
- [x] 各コミット単体でのimport・テスト可否を確認
- [x] 本番connpass APIに対して実際に `request_events()` を実行し、`soracomug-yamanashi` のイベントが分離クエリ経由で正しく取得できることを確認
- [x] CI green (`gh pr checks 24`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
