### PR TITLE
/summary/groups の並び順をstart_year順に

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -599,6 +599,10 @@ async def read_groups_summary(
         build_group_summary_from_counts(group, counts_by_group.get(group.key, {}), to_year)
         for group in groups
     ]
+    # Oldest community first; groups with no data (start_year is None)
+    # sort last, alphabetically among themselves.
+    group_summaries.sort(
+        key=lambda g: (g.start_year is None, g.start_year or 0, g.name))
 
     filtered = filter_model_fields(group_summaries, GroupSummary, fields)
     if filtered is None:

--- a/app/routes.py
+++ b/app/routes.py
@@ -599,8 +599,7 @@ async def read_groups_summary(
         build_group_summary_from_counts(group, counts_by_group.get(group.key, {}), to_year)
         for group in groups
     ]
-    # Oldest community first; groups with no data (start_year is None)
-    # sort last, alphabetically among themselves.
+    # Oldest first; no-data groups (start_year is None) sort last.
     group_summaries.sort(
         key=lambda g: (g.start_year is None, g.start_year or 0, g.name))
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -599,7 +599,6 @@ async def read_groups_summary(
         build_group_summary_from_counts(group, counts_by_group.get(group.key, {}), to_year)
         for group in groups
     ]
-    # Oldest first; no-data groups (start_year is None) sort last.
     group_summaries.sort(
         key=lambda g: (g.start_year is None, g.start_year or 0, g.name))
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1187,8 +1187,7 @@ def test_read_groups_summary(mock_get_groups_from_icalendar):
     assert by_key["Key"]["start_year"] is None
     assert by_key["Key"]["years"] == []
 
-    # Oldest community first; groups with no start_year sort last (tied
-    # among themselves alphabetically by name: "SORACOM UG 山梨" < "Title").
+    # No-start_year groups sort last, tied by name ("SORACOM UG 山梨" < "Title").
     assert [g["key"] for g in data["groups"]] == \
         ["yamanashi-web", "soracomug-yamanashi", "Key"]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1187,6 +1187,45 @@ def test_read_groups_summary(mock_get_groups_from_icalendar):
     assert by_key["Key"]["start_year"] is None
     assert by_key["Key"]["years"] == []
 
+    # Oldest community first; groups with no start_year sort last (tied
+    # among themselves alphabetically by name: "SORACOM UG 山梨" < "Title").
+    assert [g["key"] for g in data["groups"]] == \
+        ["yamanashi-web", "soracomug-yamanashi", "Key"]
+
+
+def _make_summary_event(uid, group_key, started_at):
+    return Event.from_json({
+        "uid": uid, "title": "Event", "event_url": "https://example.com",
+        "started_at": started_at, "ended_at": started_at,
+        "updated_at": started_at, "open_status": "open",
+        "group_key": group_key,
+    })
+
+
+@patch("app.service.get_full_history")
+def test_read_groups_summary_sorts_by_start_year_then_name(mock_get_full_history):
+    groups = Group.from_json([
+        {"key": "b-newer", "title": "B (newer)"},
+        {"key": "a-tie", "title": "A (tie)"},
+        {"key": "c-tie", "title": "C (tie)"},
+        {"key": "d-no-events", "title": "D (no events)"},
+    ])
+    events = [
+        _make_summary_event("uid1", "b-newer", "2020-01-01T00:00:00+09:00"),
+        _make_summary_event("uid2", "a-tie", "2015-01-01T00:00:00+09:00"),
+        _make_summary_event("uid3", "c-tie", "2015-06-01T00:00:00+09:00"),
+    ]
+    mock_get_full_history.return_value = (
+        events, groups, 2010, 2026, datetime.fromtimestamp(123, timezone.utc))
+
+    response = client.get("/summary/groups")
+    assert response.status_code == 200
+
+    data = response.json()
+    # 2015-tie broken alphabetically by name, then 2020, then no-events last.
+    assert [g["key"] for g in data["groups"]] == \
+        ["a-tie", "c-tie", "b-newer", "d-no-events"]
+
 
 @patch("app.service.ConnpassEventRequest", MockConnpassEventRequest)
 @patch("app.service.IcalEventRequest", MockICalEventRequest)


### PR DESCRIPTION
## Summary
- `/summary/groups` の `groups` 配列を `start_year` 昇順(古いコミュニティから)にソート。データが無いグループ(`start_year: null`)は末尾に、その中では名前順
- 実データで確認: `jagyamanashi`(2011) → ... → `soracomug-yamanashi`/`techmujin`/`ura-techmujin`(2026)の順に並ぶことを確認

## Test plan
- [x] `pytest`(196 passed)
- [x] 実際のAPIレスポンスでソート順を確認
- [x] コミット単体でのimport・テスト可否をworktreeで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)